### PR TITLE
Immediately update properties over IPC

### DIFF
--- a/codegen/facelift/templates/QMLImplementation.template.h
+++ b/codegen/facelift/templates/QMLImplementation.template.h
@@ -62,7 +62,7 @@ public:
     {% for operation in interface.operations %}
     {% if operation.isAsync %}
     void {{operation}}(
-        {%- for parameter in operation.parameters -%}{{parameter.cppType}} {{parameter.name}}, {% endfor %}facelift::AsyncAnswer<{{operation.cppType}}> answer) override
+        {%- for parameter in operation.parameters -%}{{parameter.cppType}} /*{{parameter.name}}*/, {% endfor %}facelift::AsyncAnswer<{{operation.cppType}}> /*answer*/) override
     {
         Q_ASSERT(false);  // TODO: implement
     }


### PR DESCRIPTION
All properties of an interface will be synchronized after a method or
property setter call now.