### PR TITLE
Add auto tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ option(FACELIFT_ENABLE_CODEGEN "Enable code generator build and install. Should 
 option(FACELIFT_ENABLE_DBUS_IPC "Force DBus IPC support (no autodetection)" OFF)
 option(FACELIFT_DISABLE_DBUS_IPC "Force disable DBus IPC support (no autodetection)" OFF)
 option(FACELIFT_BUILD_EXAMPLES "Enable build of examples" ON)
-option(FACELIFT_BUILD_TEST "Enable build of tests" OFF)
+option(FACELIFT_BUILD_TESTS "Enable build of tests" OFF)
+option(FACELIFT_BUILD_OBSOLETE_TEST "Enable build of obsolete tests" OFF)
 option(FACELIFT_ENABLE_DESKTOP_DEV_TOOLS "Enable desktop development tools" ${DEBUG_BUILD})
 
 find_package(Qt5 REQUIRED Core Gui Qml Quick)
@@ -56,10 +57,15 @@ if(FACELIFT_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-if(FACELIFT_BUILD_TEST)
+if(FACELIFT_BUILD_OBSOLETE_TEST)
     enable_testing()
     add_subdirectory(test)
     add_subdirectory(examples/test)
+endif()
+
+if(FACELIFT_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
 endif()
 
 add_subdirectory(doc)

--- a/cmake/faceliftMacros.cmake
+++ b/cmake/faceliftMacros.cmake
@@ -334,7 +334,7 @@ macro(_facelift_add_target_start)
         set(UNITY_BUILD ON)
     endif()
 
-    if(ARGUMENT_USE_QML_COMPILER)
+    if(ARGUMENT_USE_QML_COMPILER OR CMAKE_AUTOMOC)
         #qml compiler adds private definitions of V4 to RESOURCES BIN
         #combining set of resources in one file leads to redefinition error message
         set(UNITY_BUILD OFF)
@@ -571,7 +571,7 @@ endfunction()
 
 # Add a FILE and install it at the given DESTINATION in both the build folder and in the installation folder
 # The DESTINATION parameter must be a relative path
-# If specified, the RELATIVE_PATH_VARIABLE_NAME variable is set in the caller's scope and contains the path where the 
+# If specified, the RELATIVE_PATH_VARIABLE_NAME variable is set in the caller's scope and contains the path where the
 # file is located, relative to the RELATIVE_PATH_BASE parameter. That relative path is valid in both the build folder
 # and the installation folder
 function(facelift_install_file)
@@ -596,7 +596,7 @@ endfunction()
 function(facelift_add_qml_plugin PLUGIN_NAME)
 
     set(options )
-    set(oneValueArgs URI VERSION)
+    set(oneValueArgs URI VERSION OUTPUT_BASE_DIRECTORY)
     set(multiValueArgs )
     cmake_parse_arguments(ARGUMENT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -605,6 +605,10 @@ function(facelift_add_qml_plugin PLUGIN_NAME)
     if(NOT ARGUMENT_VERSION)
         # Default to version 1.0 if no version is specified
         set(ARGUMENT_VERSION "1.0")
+    endif()
+
+    if(NOT ARGUMENT_OUTPUT_BASE_DIRECTORY)
+        set(ARGUMENT_OUTPUT_BASE_DIRECTORY "import")
     endif()
 
     string(REPLACE "." ";" VERSION_LIST "${ARGUMENT_VERSION}")
@@ -619,7 +623,7 @@ function(facelift_add_qml_plugin PLUGIN_NAME)
         COMPILE_DEFINITIONS "PLUGIN_MINOR_VERSION=${PLUGIN_MINOR_VERSION};PLUGIN_MAJOR_VERSION=${PLUGIN_MAJOR_VERSION}"
     )
 
-    set(INSTALL_PATH imports/${PLUGIN_PATH})
+    set(INSTALL_PATH ${ARGUMENT_OUTPUT_BASE_DIRECTORY}/${PLUGIN_PATH})
 
     set_target_properties(${PLUGIN_NAME} PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${INSTALL_PATH}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+find_program (QT_QML_TEST_RUNNER NAMES qmltestrunner)
+find_program (QT_QML_BINARY NAMES qml)
+configure_file(test-driver.sh.in test-driver.sh @ONLY)
+
+
+if (CMAKE_CONFIGURATION_TYPES)
+    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure
+                      --build-config "$<CONFIGURATION>")
+else()
+    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure)
+endif()
+
+
+add_subdirectory(combined)
+add_test(NAME combined-local-cpp COMMAND test-driver.sh combined/tst_combined_local.qml cpp)
+add_test(NAME combined-local-qml COMMAND test-driver.sh combined/tst_combined_local.qml qml)
+add_test(NAME combined-ipc-cpp COMMAND test-driver.sh combined/tst_combined_ipc.qml cpp combined/combined-server.qml)
+add_test(NAME combined-ipc-qml COMMAND test-driver.sh combined/tst_combined_ipc.qml qml combined/combined-server.qml)
+add_test(NAME combined-inprocess-cpp COMMAND test-driver.sh combined/tst_combined_inprocess.qml cpp)
+add_test(NAME combined-inprocess-qml COMMAND test-driver.sh combined/tst_combined_inprocess.qml qml)

--- a/tests/combined/CMakeLists.txt
+++ b/tests/combined/CMakeLists.txt
@@ -1,0 +1,19 @@
+facelift_add_interface(CombinedInterface INTERFACE_DEFINITION_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/interface)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+
+facelift_add_qml_plugin(CombinedTestsPluginCpp
+   URI tests.combined
+   OUTPUT_BASE_DIRECTORY import/cpp
+   SOURCES plugin/CombinedTestsPlugin.cpp
+   LINK_LIBRARIES CombinedInterface
+)
+
+facelift_add_qml_plugin(CombinedTestsPluginQml
+   URI tests.combined
+   OUTPUT_BASE_DIRECTORY import/qml
+   SOURCES plugin/CombinedTestsPlugin.cpp
+   LINK_LIBRARIES CombinedInterface
+)
+target_compile_definitions(CombinedTestsPluginQml PRIVATE -DQML_IMPL_LOCATION=${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/combined/check_combined.js
+++ b/tests/combined/check_combined.js
@@ -1,0 +1,101 @@
+/**********************************************************************
+**
+** Copyright (C) 2018 Luxoft Sweden AB
+**
+** This file is part of the FaceLift project
+**
+** Permission is hereby granted, free of charge, to any person
+** obtaining a copy of this software and associated documentation files
+** (the "Software"), to deal in the Software without restriction,
+** including without limitation the rights to use, copy, modify, merge,
+** publish, distribute, sublicense, and/or sell copies of the Software,
+** and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+** NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+** ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+**
+** SPDX-License-Identifier: MIT
+**
+**********************************************************************/
+
+function defaults() {
+    tryVerify(function() { return api.ready; });
+
+    compare(api.boolProperty, false);
+    compare(api.enumProperty, CombiEnum.E1);
+    compare(api.writableEnumProperty, 0);
+    compare(api.intProperty, 0);
+
+    compare(api.structProperty.anInt, 0);
+    compare(api.structProperty.aString, "");
+    compare(api.structProperty2.cs.anInt, 0);
+    compare(api.structProperty2.cs.aString, "");
+    compare(api.structProperty2.e, 0);
+
+    compare(api.intListProperty, []);
+    compare(api.boolListProperty.length, 0);
+    compare(api.enumListProperty.length, 0);
+    compare(api.stringListProperty.length, 0);
+    compare(api.structListProperty.length, 0);
+
+    compare(api.intMapProperty.one, undefined);
+}
+
+function initialized() {
+    api.initialize();
+
+    tryVerify(function() { return api.boolProperty; });
+
+    compare(api.boolProperty, true);
+    compare(api.enumProperty, CombiEnum.E2);
+    compare(api.writableEnumProperty, 2);
+    compare(api.intProperty, 17);
+
+    compare(api.structProperty.anInt, 21);
+    compare(api.structProperty.aString, "ok");
+    compare(api.structProperty2.cs.anInt, 21);
+    compare(api.structProperty2.cs.aString, "ok");
+    compare(api.structProperty2.e, 1);
+
+    if (!api.qmlImplementationUsed) {
+        api.interfaceProperty.doSomething();
+    }
+
+    compare(api.intListProperty.length, 5);
+    compare(api.intListProperty[2], 3);
+    compare(api.boolListProperty.length, 3);
+    compare(api.boolListProperty[2], true);
+    compare(api.enumListProperty.length, 1);
+    verify(api.enumListProperty[0] == CombiEnum.E2)   // replace with:
+    //compare(api.enumListProperty[0], CombiEnum.E2); // once types are fixed
+    compare(api.stringListProperty.length, 3);
+    compare(api.stringListProperty[0], "one");
+
+    if (!api.qmlImplementationUsed) {
+        compare(api.structListProperty.length, 2);
+        compare(api.structListProperty[0].anInt, 21);
+        compare(api.structListProperty[0].aString, "ok");
+        compare(api.structListProperty[1].aString, "nok");
+    }
+
+    compare(api.intMapProperty.one, 1);
+    compare(api.intMapProperty.two, 2);
+}
+
+function setter() {
+    api.intProperty = -12;
+    compare(api.intProperty, 0);
+
+    api.stringListProperty = [ "11", "22"];
+    compare(api.stringListProperty[0], "11");
+}

--- a/tests/combined/combined-server.qml
+++ b/tests/combined/combined-server.qml
@@ -1,0 +1,36 @@
+/**********************************************************************
+**
+** Copyright (C) 2018 Luxoft Sweden AB
+**
+** This file is part of the FaceLift project
+**
+** Permission is hereby granted, free of charge, to any person
+** obtaining a copy of this software and associated documentation files
+** (the "Software"), to deal in the Software without restriction,
+** including without limitation the rights to use, copy, modify, merge,
+** publish, distribute, sublicense, and/or sell copies of the Software,
+** and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+** NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+** ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+**
+** SPDX-License-Identifier: MIT
+**
+**********************************************************************/
+
+import tests.combined 1.0
+
+CombinedInterfaceAPI {
+    IPC.enabled: true
+    IPC.objectPath: "/tests/combined/ipc"
+}

--- a/tests/combined/impl/cpp/CombinedTestsCppImplementation.h
+++ b/tests/combined/impl/cpp/CombinedTestsCppImplementation.h
@@ -1,0 +1,156 @@
+/**********************************************************************
+**
+** Copyright (C) 2018 Luxoft Sweden AB
+**
+** This file is part of the FaceLift project
+**
+** Permission is hereby granted, free of charge, to any person
+** obtaining a copy of this software and associated documentation files
+** (the "Software"), to deal in the Software without restriction,
+** including without limitation the rights to use, copy, modify, merge,
+** publish, distribute, sublicense, and/or sell copies of the Software,
+** and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+** NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+** ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+**
+** SPDX-License-Identifier: MIT
+**
+**********************************************************************/
+
+#pragma once
+
+#include "tests/combined/CombinedInterfacePropertyAdapter.h"
+#include "tests/combined/CombinedInterface2PropertyAdapter.h"
+
+
+using namespace tests::combined;
+
+
+class CombinedInterfaceCppImplementation : public CombinedInterfacePropertyAdapter
+{
+    class CombinedInterface2Implementation : public CombinedInterface2PropertyAdapter
+    {
+    public:
+        CombinedInterface2Implementation(CombinedInterfaceCppImplementation* parent, QString id)
+            : CombinedInterface2PropertyAdapter(parent)
+        {
+            m_id = id;
+        }
+
+        void doSomething() override
+        {
+            qDebug() << "doSomething() called, id =" << m_id;
+        }
+
+        QString m_id;
+    };
+
+public:
+    CombinedInterfaceCppImplementation(QObject *parent = nullptr) : CombinedInterfacePropertyAdapter(parent)
+    {
+        qDebug() << "C++ implementation is used.";
+        m_readyProperty = 0;
+        m_readyProperty.setReady(false);
+    }
+
+    void initialize() override
+    {
+        m_boolProperty = true;
+        m_enumProperty = CombiEnum::E2;
+        m_writableEnumProperty = CombiEnum::E3;
+        m_intProperty = 17;
+        CombiStruct s;
+        s.setanInt(21);
+        s.setaString("ok");
+        m_structProperty = s;
+        CombiStruct2 s2;
+        s2.setcs(s);
+        s2.sete(CombiEnum::E2);
+        m_structProperty2 = s2;
+
+        m_interfaceProperty.setValue(new CombinedInterface2Implementation(this, "#7"));
+
+        m_intListProperty = { 1, 2, 3, 5, 8 };
+        m_boolListProperty = { false, true, true };
+        m_enumListProperty = { CombiEnum::E2 };
+        m_stringListProperty = { QStringLiteral("one"), QStringLiteral("two"), QStringLiteral("three") };
+
+        CombiStruct c;
+        c.setaString("nok");
+        m_structListProperty = { s, c };
+
+        m_intMapProperty = QMap<QString, int> { { "one", 1 }, { "two", 2 } };
+
+        m_readyProperty = 42;
+    }
+
+    void setintProperty(const int &newValue) override
+    {
+        m_intProperty = newValue > 0 ? newValue : 0;
+    }
+
+    void setintMapProperty(const QMap<QString, int>& newValue) override
+    {
+        m_intMapProperty = newValue;
+    }
+
+    void setwritableEnumProperty(const CombiEnum & /*newValue*/) override
+    {
+    }
+
+    void setstructProperty(const CombiStruct & /*newValue*/) override
+    {
+    }
+
+    void setstructProperty2(const CombiStruct2 & /*newValue*/) override
+    {
+    }
+
+    void setstringListProperty(const QList<QString> & newValue) override
+    {
+        qDebug() << "set stringListProperty:" << newValue;
+        m_stringListProperty = newValue;
+    }
+
+    void setreadyProperty(const int &newValue) override
+    {
+        qDebug() << "set readyProperty:" << newValue;
+        m_intProperty = newValue;
+    }
+
+    QString method1() override
+    {
+        return QString();
+    }
+
+    CombiStruct2 method2(int /*intParam*/, bool /*boolParam*/) override
+    {
+        return CombiStruct2();
+    }
+
+    CombiEnum method3() override
+    {
+        return CombiEnum();
+    }
+
+    QList<CombiEnum> method4(CombiStruct2 /*s*/)  override
+    {
+        return QList<CombiEnum>();
+    }
+
+    QList<CombiStruct> method5() override
+    {
+        return QList<CombiStruct>();
+    }
+};

--- a/tests/combined/impl/qml/CombinedTestsQmlImplementation.qml
+++ b/tests/combined/impl/qml/CombinedTestsQmlImplementation.qml
@@ -1,0 +1,76 @@
+/**********************************************************************
+**
+** Copyright (C) 2018 Luxoft Sweden AB
+**
+** This file is part of the FaceLift project
+**
+** Permission is hereby granted, free of charge, to any person
+** obtaining a copy of this software and associated documentation files
+** (the "Software"), to deal in the Software without restriction,
+** including without limitation the rights to use, copy, modify, merge,
+** publish, distribute, sublicense, and/or sell copies of the Software,
+** and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+** NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+** ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+**
+** SPDX-License-Identifier: MIT
+**
+**********************************************************************/
+
+import QtQuick 2.0
+import tests.combined 1.0
+
+
+CombinedInterfaceQMLImplementation {
+    id: root
+    qmlImplementationUsed: true
+
+//    CombinedInterface2QMLImplementation {
+//        id: ci2
+
+//        doSomething: function() {
+//            console.log("doSomething() called, id = " + id);
+//        }
+//    }
+
+    setintProperty: function(i) {
+        root.intProperty = i > 0 ? i : 0;
+    }
+
+    setstringListProperty: function(sl) {
+        stringListProperty = sl;
+    }
+
+    initialize: function() {
+        boolProperty = true;
+        enumProperty = CombiEnum.E2;
+        writableEnumProperty = CombiEnum.E3;
+        intProperty = 17;
+
+        structProperty.anInt = 21;
+        structProperty.aString = "ok";
+        structProperty2.cs = structProperty;
+        structProperty2.cs.aString = "ok";
+        structProperty2.e = CombiEnum.E2;
+
+        intListProperty = [ 1, 2, 3, 5, 8 ];
+        boolListProperty = [ false, true, true ];
+        enumListProperty = [ CombiEnum.E2 ];
+        stringListProperty = [ "one", "two", "three" ];
+
+        intMapProperty = { one: 1, two: 2 };
+    }
+
+    Component.onCompleted: console.log("QML implementation is used.");
+}

--- a/tests/combined/interface/combined.qface
+++ b/tests/combined/interface/combined.qface
@@ -1,0 +1,100 @@
+/**********************************************************************
+**
+** Copyright (C) 2018 Luxoft Sweden AB
+**
+** This file is part of the FaceLift project
+**
+** Permission is hereby granted, free of charge, to any person
+** obtaining a copy of this software and associated documentation files
+** (the "Software"), to deal in the Software without restriction,
+** including without limitation the rights to use, copy, modify, merge,
+** publish, distribute, sublicense, and/or sell copies of the Software,
+** and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+** NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+** ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+**
+** SPDX-License-Identifier: MIT
+**
+**********************************************************************/
+
+module tests.combined 1.0
+
+interface CombinedInterface {
+    readonly bool qmlImplementationUsed;
+    void initialize();
+
+    readonly bool boolProperty;
+    readonly CombiEnum enumProperty;
+    CombiEnum writableEnumProperty;
+    int intProperty;
+    CombiStruct structProperty;
+    CombiStruct2 structProperty2;
+
+    readonly CombinedInterface2 interfaceProperty;
+    readonly list<CombinedInterface2> interfaceListProperty;
+    readonly list<int> intListProperty;
+    readonly list<bool> boolListProperty;
+    readonly list<CombiEnum> enumListProperty;
+
+    list<string> stringListProperty;
+
+    readonly list<CombiStruct> structListProperty;
+
+    readonly map<CombinedInterface2> interfaceMapProperty;
+    readonly map<CombiStruct> structMapProperty;
+    map<int> intMapProperty;
+
+    @hasReadyFlag: true
+    int readyProperty;
+
+    string method1();
+    CombiStruct2 method2(int intParam, bool boolParam);
+    CombiEnum method3();
+    list<CombiEnum> method4(CombiStruct2 s);
+    list<CombiStruct> method5();
+
+    signal event1(CombiStruct p);
+    signal eventCombiEnum(CombiEnum p);
+    signal eventInt(int p);
+    signal eventBoolAndCombiStruct(bool p, CombiStruct q);
+    signal eventWithList(list<int> p, bool q);
+    signal eventWithMap(map<int> p);
+    signal eventWithStructWithList(StructWithList p)
+}
+
+interface CombinedInterface2 {
+    void doSomething();
+}
+
+struct CombiStruct {
+    string aString;
+    int anInt;
+}
+
+struct CombiStruct2 {
+    CombiStruct cs;
+    CombiEnum e;
+}
+
+struct StructWithList {
+    list<int> listOfInts;
+    list<CombiStruct> listOfStructs;
+    CombiEnum enumField;
+}
+
+enum CombiEnum {
+    E1,
+    E2,
+    E3,
+}

--- a/tests/combined/plugin/CombinedTestsPlugin.cpp
+++ b/tests/combined/plugin/CombinedTestsPlugin.cpp
@@ -1,0 +1,53 @@
+/**********************************************************************
+**
+** Copyright (C) 2018 Luxoft Sweden AB
+**
+** This file is part of the FaceLift project
+**
+** Permission is hereby granted, free of charge, to any person
+** obtaining a copy of this software and associated documentation files
+** (the "Software"), to deal in the Software without restriction,
+** including without limitation the rights to use, copy, modify, merge,
+** publish, distribute, sublicense, and/or sell copies of the Software,
+** and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+** NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+** ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+**
+** SPDX-License-Identifier: MIT
+**
+**********************************************************************/
+
+#include "CombinedTestsPlugin.h"
+#include "tests/combined/Module.h"
+#if defined(QML_IMPL_LOCATION)
+#  include "tests/combined/CombinedInterfaceQMLImplementation.h"
+#else
+#  include "impl/cpp/CombinedTestsCppImplementation.h"
+#endif
+
+
+using namespace tests::combined;
+
+void CombinedTestsPlugin::registerTypes(const char *uri)
+{
+    Module::registerQmlTypes(uri);
+    Module::registerUncreatableQmlTypes(uri);
+
+#if defined(QML_IMPL_LOCATION)
+    facelift::registerQmlComponent<CombinedInterfaceQMLImplementation>(uri, STRINGIFY(QML_IMPL_LOCATION)
+            "/impl/qml/CombinedTestsQmlImplementation.qml", "CombinedInterfaceAPI");
+#else
+    facelift::registerQmlComponent<CombinedInterfaceCppImplementation>(uri, "CombinedInterfaceAPI");
+#endif
+}

--- a/tests/combined/plugin/CombinedTestsPlugin.h
+++ b/tests/combined/plugin/CombinedTestsPlugin.h
@@ -1,0 +1,42 @@
+/**********************************************************************
+**
+** Copyright (C) 2018 Luxoft Sweden AB
+**
+** This file is part of the FaceLift project
+**
+** Permission is hereby granted, free of charge, to any person
+** obtaining a copy of this software and associated documentation files
+** (the "Software"), to deal in the Software without restriction,
+** including without limitation the rights to use, copy, modify, merge,
+** publish, distribute, sublicense, and/or sell copies of the Software,
+** and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+** NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+** ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+**
+** SPDX-License-Identifier: MIT
+**
+**********************************************************************/
+
+#pragma once
+
+#include <QQmlExtensionPlugin>
+
+class CombinedTestsPlugin : public QQmlExtensionPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "pelagicore.facelift.tests")
+
+public:
+    void registerTypes(const char *uri) override;
+};

--- a/tests/combined/tst_combined_inprocess.qml
+++ b/tests/combined/tst_combined_inprocess.qml
@@ -1,0 +1,60 @@
+/**********************************************************************
+**
+** Copyright (C) 2018 Luxoft Sweden AB
+**
+** This file is part of the FaceLift project
+**
+** Permission is hereby granted, free of charge, to any person
+** obtaining a copy of this software and associated documentation files
+** (the "Software"), to deal in the Software without restriction,
+** including without limitation the rights to use, copy, modify, merge,
+** publish, distribute, sublicense, and/or sell copies of the Software,
+** and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+** NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+** ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+**
+** SPDX-License-Identifier: MIT
+**
+**********************************************************************/
+
+import QtTest 1.2
+import tests.combined 1.0
+import "check_combined.js" as Check
+
+
+TestCase {
+    name: "combined-inprocess"
+
+    CombinedInterfaceAPI {
+        IPC.enabled: true
+        IPC.objectPath: "/tests/combined/inprocess"
+    }
+
+    CombinedInterfaceIPCProxy {
+        id: api
+        ipc.objectPath: "/tests/combined/inprocess"
+    }
+
+
+    function initTestCase() {
+        Check.defaults();
+        Check.initialized();
+
+        // readyFlag not supported over (pseudo, inprocess) IPC
+    }
+
+    function test_setter() {
+        Check.setter();
+    }
+}

--- a/tests/combined/tst_combined_ipc.qml
+++ b/tests/combined/tst_combined_ipc.qml
@@ -1,0 +1,54 @@
+/**********************************************************************
+**
+** Copyright (C) 2018 Luxoft Sweden AB
+**
+** This file is part of the FaceLift project
+**
+** Permission is hereby granted, free of charge, to any person
+** obtaining a copy of this software and associated documentation files
+** (the "Software"), to deal in the Software without restriction,
+** including without limitation the rights to use, copy, modify, merge,
+** publish, distribute, sublicense, and/or sell copies of the Software,
+** and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+** NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+** ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+**
+** SPDX-License-Identifier: MIT
+**
+**********************************************************************/
+
+import QtTest 1.2
+import tests.combined 1.0
+import "check_combined.js" as Check
+
+TestCase {
+    name: "combined-ipc"
+
+    CombinedInterfaceIPCProxy {
+        id: api
+        ipc.objectPath: "/tests/combined/ipc"
+    }
+
+
+    function initTestCase() {
+        Check.defaults();
+        Check.initialized();
+
+        // readyFlag not supported over IPC
+    }
+
+    function test_setter() {
+        Check.setter(api);
+    }
+}

--- a/tests/combined/tst_combined_local.qml
+++ b/tests/combined/tst_combined_local.qml
@@ -1,0 +1,70 @@
+/**********************************************************************
+**
+** Copyright (C) 2018 Luxoft Sweden AB
+**
+** This file is part of the FaceLift project
+**
+** Permission is hereby granted, free of charge, to any person
+** obtaining a copy of this software and associated documentation files
+** (the "Software"), to deal in the Software without restriction,
+** including without limitation the rights to use, copy, modify, merge,
+** publish, distribute, sublicense, and/or sell copies of the Software,
+** and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+** NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+** ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+**
+** SPDX-License-Identifier: MIT
+**
+**********************************************************************/
+
+import QtTest 1.2
+import tests.combined 1.0
+import "check_combined.js" as Check
+
+TestCase {
+    name: "combined-local"
+
+    CombinedInterfaceAPI {
+        id: api
+    }
+
+    SignalSpy {
+        id: readyFlagsChangedSpy
+        target: api
+        signalName: "readyFlagsChanged"
+    }
+
+
+    function initTestCase() {
+        compare(api.interfaceProperty, null);
+
+        // hasReadyFlag is only supported by C++ backend:
+        if (!api.qmlImplementationUsed) {
+            verify(!api.readyFlags.readyProperty);
+        }
+
+        Check.defaults();
+        Check.initialized();
+
+        if (!api.qmlImplementationUsed) {
+            readyFlagsChangedSpy.wait(2000);
+            verify(api.readyFlags.readyProperty);
+            compare(api.readyProperty, 42);
+        }
+    }
+
+    function test_setter() {
+        Check.setter();
+    }
+}

--- a/tests/test-driver.sh.in
+++ b/tests/test-driver.sh.in
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+# Arguments:
+# 1. Test path/file (relative to "tests" folder)
+# 2. Backend to use (cpp or qml)
+# 3. Optional server to run (relative to "tests" folder)
+
+SRC_FOLDER=@CMAKE_SOURCE_DIR@
+BUILD_FOLDER=@CMAKE_BINARY_DIR@
+QML_BINARY=@QT_QML_BINARY@
+QML_TEST_RUNNER=@QT_QML_TEST_RUNNER@
+
+export QT_LOGGING_RULES="*=false;*.warning=true;*.critical=true"
+
+# start optional server provided in $3
+if [[ $3 ]] ; then
+    echo "INVOKING: ${QML_BINARY} $SRC_FOLDER/tests/$3 -I $BUILD_FOLDER/import/$2"
+    ${QML_BINARY} "$SRC_FOLDER/tests/$3" -I "$BUILD_FOLDER/import/$2" &
+    sleep 0.1
+fi
+
+# execute test provided in $1 with backend provided in $2 (cpp or qml)
+echo "Invoking: $QML_TEST_RUNNER -input $SRC_FOLDER/tests/$1 -import $BUILD_FOLDER/import/$2"
+$QML_TEST_RUNNER -input "$SRC_FOLDER/tests/$1" -import "$BUILD_FOLDER/import/$2"
+
+EXIT_CODE=$?
+
+# kill qml background server process
+[[ $3 ]] && kill $!
+
+exit $EXIT_CODE


### PR DESCRIPTION
Inital auto tests based on QtTest have been added. The frontend (UI)
facing interface is tested. There are six test combinations: local,
via ipc and inprocess (server and client in one process), all three
with C++ and QML backend.