### PR TITLE
fixed compile error for MSVC based compilers

### DIFF
--- a/src/common/FaceliftUtils.h
+++ b/src/common/FaceliftUtils.h
@@ -219,14 +219,14 @@ private:
     std::unordered_map<Key, decltype(m_list.begin())> m_map;
 };
 
-#ifdef FaceliftCommonLib_EXPORTS
-#define FaceliftCommonLib_API __declspec(dllexport)
-#elif defined(FaceliftCommonLib_EXPORTS_STATIC)
-#define FaceliftCommonLib_API
+#if defined(FaceliftCommonLib_LIBRARY)
+#  define FaceliftCommonLib_EXPORT Q_DECL_EXPORT
 #else
-#define FaceliftCommonLib_API __declspec(dllimport)
+#  define FaceliftCommonLib_EXPORT Q_DECL_IMPORT
 #endif
 
+// this dummy export is neccessary for creating a *.lib file with MSVC based compiler
+// otherwise no lib file will be created
+FaceliftCommonLib_EXPORT int dummy_value_1;
 
-FaceliftCommonLib_API int value;
 }

--- a/src/common/FaceliftUtils.h
+++ b/src/common/FaceliftUtils.h
@@ -219,4 +219,14 @@ private:
     std::unordered_map<Key, decltype(m_list.begin())> m_map;
 };
 
+#ifdef FaceliftCommonLib_EXPORTS
+#define FaceliftCommonLib_API __declspec(dllexport)
+#elif defined(FaceliftCommonLib_EXPORTS_STATIC)
+#define FaceliftCommonLib_API
+#else
+#define FaceliftCommonLib_API __declspec(dllimport)
+#endif
+
+
+FaceliftCommonLib_API int value;
 }

--- a/src/ipc/dbus/ipc-dbus.h
+++ b/src/ipc/dbus/ipc-dbus.h
@@ -316,7 +316,7 @@ template<size_t I = 0, typename ... Ts>
 typename std::enable_if < I<sizeof ... (Ts)>::type
 appendDBUSTypeSignature(QTextStream &s, std::tuple<Ts ...> &t)
 {
-    typedef typeof (std::get<I>(t)) Type;
+    using Type = decltype(std::get<I>(t));
     IPCTypeHandler<Type>::writeDBUSSignature(s);
     appendDBUSTypeSignature<I + 1>(s, t);
 }
@@ -477,7 +477,7 @@ typename std::enable_if < I<sizeof ... (Ts)>::type
 appendDBUSMethodArgumentsSignature(QTextStream &s, std::tuple<Ts ...> &t, const std::array<const char *,
         sizeof ... (Ts)> &argNames)
 {
-    typedef typeof (std::get<I>(t)) Type;
+    using Type = decltype(std::get<I>(t));
     s << "<arg name=\"" << argNames[I] << "\" type=\"";
     IPCTypeHandler<Type>::writeDBUSSignature(s);
     s << "\" direction=\"in\"/>";
@@ -500,7 +500,7 @@ typename std::enable_if < I<sizeof ... (Ts)>::type
 appendDBUSSignalArgumentsSignature(QTextStream &s, std::tuple<Ts ...> &t, const std::array<const char *,
         sizeof ... (Ts)> &argNames)
 {
-    typedef typeof (std::get<I>(t)) Type;
+    using Type = decltype(std::get<I>(t));
     s << "<arg name=\"" << argNames[I] << "\" type=\"";
     IPCTypeHandler<Type>::writeDBUSSignature(s);
     s << "\"/>";

--- a/src/ipc/ipc.cpp
+++ b/src/ipc/ipc.cpp
@@ -32,4 +32,15 @@
 
 namespace facelift {
 
+#ifdef FaceliftIPCLib_EXPORTS
+#define FaceliftIPC_API __declspec(dllexport)
+#elif defined(FaceliftIPCLib_EXPORTS_STATIC)
+#define FaceliftIPC_API
+#else
+#define FaceliftIPC_API __declspec(dllimport)
+#endif
+
+
+FaceliftIPC_API int value_2;
+
 }

--- a/src/ipc/ipc.cpp
+++ b/src/ipc/ipc.cpp
@@ -32,15 +32,14 @@
 
 namespace facelift {
 
-#ifdef FaceliftIPCLib_EXPORTS
-#define FaceliftIPC_API __declspec(dllexport)
-#elif defined(FaceliftIPCLib_EXPORTS_STATIC)
-#define FaceliftIPC_API
+#if defined(FaceliftIPCLib_LIBRARY)
+#  define FaceliftIPCLib_EXPORT Q_DECL_EXPORT
 #else
-#define FaceliftIPC_API __declspec(dllimport)
+#  define FaceliftIPCLib_EXPORT Q_DECL_IMPORT
 #endif
 
-
-FaceliftIPC_API int value_2;
+// this dummy export is neccessary for creating a *.lib file with MSVC based compiler
+// otherwise no lib file will be created
+FaceliftIPCLib_EXPORT int dummy_value_2;
 
 }


### PR DESCRIPTION
There will be no LIB file generated, when nothing will be exported.
And when linking to another library a lib file will be needed, otherwise we get a linker error from MSVC.

This will add some dummy exports.

Additional:
"typedef typeof (std::get<I>(t)) Type;" is not valid C++ code and lead to compile error under MSVC

Replaced it with:
"using Type = decltype(std::get<I>(t));"