### PR TITLE
Add support init appveyor support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,6 +16,7 @@ build:
 
 install:
   - cd %APPVEYOR_BUILD_FOLDER%
+  - dir
   - git submodule update --init --recursive
   - mkdir C:\projects\deps
   - cd C:\projects\deps

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ install:
 before_build:
   - cmd: cd %APPVEYOR_BUILD_FOLDER%
   - cmd: set PATH=C:\Python37-x64;%PATH%
-  - cmd: python -m pip install click
+  - cmd: python -m pip install antlr4-python3-runtime six pyyaml click typing jinja2 watchdog path.py
   - IF "%ARCHITECTURE%" == "x64" IF "%COMPILER%" == "MSVC_15" set PATH=C:\Qt\5.11.1\msvc2017_64\bin;%PATH%
   - IF "%ARCHITECTURE%" == "x64" IF "%COMPILER%" == "MSVC_15" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
   - IF "%ARCHITECTURE%" == "x86" IF "%COMPILER%" == "MINGW_532" set PATH=C:\Qt\Tools\mingw530_32\bin;C:\Qt\5.11.1\mingw53_32\bin;%PATH%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,57 @@
+shallow_clone: true
+
+environment:
+  matrix:
+  - COMPILER: MSVC_15
+    ARCHITECTURE: x64
+    BUILD_TESTS: true
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  - COMPILER: MINGW_532
+    ARCHITECTURE: x86
+    BUILD_TESTS: true
+
+build:
+  verbosity: detailed
+  parallel: true
+
+install:
+  - mkdir C:\projects\deps
+  - cd C:\projects\deps
+
+  #######################################################################################
+  # Install Ninja
+  #######################################################################################
+  - set NINJA_URL="https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip"
+  - appveyor DownloadFile %NINJA_URL% -FileName ninja.zip
+  - 7z x ninja.zip -oC:\projects\deps\ninja > nul
+  - set PATH=C:\projects\deps\ninja;%PATH%
+  - ninja --version
+  
+  #######################################################################################
+  # Install doxygen
+  #######################################################################################
+  - ps: >-
+      If ($env:BUILD_DOCU -Match "true") {
+        $env:DOXYGEN_URL="http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.10.windows.bin.zip"
+        appveyor DownloadFile $env:DOXYGEN_URL -FileName doxygen.zip
+        7z x doxygen.zip -oC:/projects/deps/doxygen-1.8.10 > $null
+        $env:PATH="C:/projects/deps/doxygen-1.8.10;$env:PATH"
+        doxygen --version
+      }
+
+before_build:
+  - cmd: cd C:/Qt/5.11.1
+  - cmd: dir
+  - cmd: cd C:\projects\facelift
+  - cmd: set PATH=C:\Python37-x64;%PATH%
+  - cmd: python -m pip install click qface
+  - IF "%ARCHITECTURE%" == "x64" IF "%COMPILER%" == "MSVC_15" set PATH=C:\Qt\5.11.1\msvc2017_64\bin;%PATH%
+  - IF "%ARCHITECTURE%" == "x64" IF "%COMPILER%" == "MSVC_15" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
+  - IF "%ARCHITECTURE%" == "x86" IF "%COMPILER%" == "MINGW_532" set PATH=C:\Qt\Tools\mingw530_32\bin;C:\Qt\5.11.1\mingw53_32\bin;%PATH%
+
+build_script:
+  - mkdir build
+  - cd build
+  - cmake .. -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DFACELIFT_BUILD_TESTS=%BUILD_TESTS%
+  - ninja
+ # - if "%BUILD_TESTS%" == "true" (ctest) # when you want to run the tests, use this uncomment this line

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,8 @@ build:
   parallel: true
 
 install:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - git submodule update --init --recursive
   - mkdir C:\projects\deps
   - cd C:\projects\deps
 
@@ -42,7 +44,7 @@ install:
 before_build:
   - cmd: cd C:\projects\facelift
   - cmd: set PATH=C:\Python37-x64;%PATH%
-  - cmd: python -m pip install click qface
+  - cmd: python -m pip install click
   - IF "%ARCHITECTURE%" == "x64" IF "%COMPILER%" == "MSVC_15" set PATH=C:\Qt\5.11.1\msvc2017_64\bin;%PATH%
   - IF "%ARCHITECTURE%" == "x64" IF "%COMPILER%" == "MSVC_15" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
   - IF "%ARCHITECTURE%" == "x86" IF "%COMPILER%" == "MINGW_532" set PATH=C:\Qt\Tools\mingw530_32\bin;C:\Qt\5.11.1\mingw53_32\bin;%PATH%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,3 @@
-shallow_clone: true
-
 environment:
   matrix:
   - COMPILER: MSVC_15
@@ -16,7 +14,6 @@ build:
 
 install:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - dir
   - git submodule update --init --recursive
   - mkdir C:\projects\deps
   - cd C:\projects\deps
@@ -43,7 +40,7 @@ install:
       }
 
 before_build:
-  - cmd: cd C:\projects\facelift
+  - cmd: cd %APPVEYOR_BUILD_FOLDER%
   - cmd: set PATH=C:\Python37-x64;%PATH%
   - cmd: python -m pip install click
   - IF "%ARCHITECTURE%" == "x64" IF "%COMPILER%" == "MSVC_15" set PATH=C:\Qt\5.11.1\msvc2017_64\bin;%PATH%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,8 +40,6 @@ install:
       }
 
 before_build:
-  - cmd: cd C:/Qt/5.11.1
-  - cmd: dir
   - cmd: cd C:\projects\facelift
   - cmd: set PATH=C:\Python37-x64;%PATH%
   - cmd: python -m pip install click qface


### PR DESCRIPTION
Tests are not running, because they are written as *.sh scripts.
@jacky309 
When this PR is merged, you need to connect this repo to https://ci.appveyor.com/ via github, in order to see an effect.

Fixes #82