### PR TITLE
add ci badges inside readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Travis status](https://travis-ci.com/Pelagicore/facelift.svg?branch=master)](https://travis-ci.com/Pelagicore/facelift)
+[![Appveyor status](https://ci.appveyor.com/api/projects/status/github/pelagicore/facelift?svg=true&branch=master)](https://ci.appveyor.com/project/weimerb/facelift)
+
 # Motivation
 
 This software has been created in order to help solving problems which are typically arising when developing complex UI software using the Qt/QML framework. This kind of system is usually designed in such a way that some C++ code exposes functionality to the QML engine. The typical challenges are the following:


### PR DESCRIPTION
1. This allows to see easily that this repo is using CI
2. Can easily jump to the CI servers via link
3. The status of these badges will change dynamically when the build breaks or runs through