### PR TITLE
Remove "sudo: false" from .travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
 dist: xenial
-sudo: false
 
 git:
   depth: 10


### PR DESCRIPTION
This is recommended due to the switch from containers to VMs on
Travis. See:
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration