### PR TITLE
[QMLFrontend] Add detailed log when JS callback execution failed

### DIFF
--- a/src/model/QMLFrontend.h
+++ b/src/model/QMLFrontend.h
@@ -123,7 +123,11 @@ protected:
                 appendJSValue(jsList, engine, args...);
                 auto returnValue = callback.call(jsList);
                 if (returnValue.isError()) {
-                    qCritical("Error executing JS callback");
+                    qCritical().noquote() << "Error executing JS callback. Error type:" << returnValue.property("name").toString()
+                                          << "\nFile:" << returnValue.property("fileName").toString()
+                                          << "\nLine:" << returnValue.property("lineNumber").toInt()
+                                          << "\nMessage:" << returnValue.property("message").toString()
+                                          << "\nStack trace:" << returnValue.property("stack").toString();
                 }
             } else {
                 qCritical("Provided JS object is not callable");


### PR DESCRIPTION
In case if JS call execution will fail following information will be
displayed for better debugging:
1. Message that execution failed and error type (QJSValue::ErrorType)
2. File name where exception was thrown
3. Line in file
4. Message - what exactly was happend (example: PropertyName is not defined)
5. Stack trace which leads to JS error