### PR TITLE
fix missing add of FaceliftEnum.h to FaceliftModelLib

### DIFF
--- a/src/model/CMakeLists.txt
+++ b/src/model/CMakeLists.txt
@@ -1,6 +1,25 @@
 
 facelift_add_library(FaceliftModelLib
-    SOURCES FaceliftModel.cpp QMLFrontend.cpp ServiceWrapper.cpp StructureBase.cpp ModuleBase.cpp QMLModel.cpp FaceliftProperty.cpp
-    HEADERS FaceliftModel.h QMLFrontend.h ServiceWrapper.h StructureBase.h ModuleBase.h ServiceRegistry.h StructQObjectWrapper.h QMLModel.h FaceliftProperty.h FaceliftConversion.h FaceliftCommon.h FaceliftEnum.h
+    SOURCES 
+        FaceliftModel.cpp
+        FaceliftProperty.cpp
+        ModuleBase.cpp
+        QMLFrontend.cpp
+        QMLModel.cpp
+        ServiceWrapper.cpp
+        StructureBase.cpp
+    HEADERS 
+        FaceliftCommon.h
+        FaceliftConversion.h
+        FaceliftEnum.h
+        FaceliftModel.h
+        FaceliftProperty.h
+        ModuleBase.h
+        QMLFrontend.h
+        QMLModel.h
+        ServiceRegistry.h
+        ServiceWrapper.h
+        StructQObjectWrapper.h
+        StructureBase.h
     LINK_LIBRARIES FaceliftCommonLib Qt5::Qml Qt5::Quick
 )


### PR DESCRIPTION
When using a cmake generated installation of facelift
this header was not installed properly.

Remark: A unit test for testing the facelift installation would be nice.