### PR TITLE
ServiceWrapper: emit readyChanged each time when impl has been changed

### DIFF
--- a/src/model/ServiceWrapper.h
+++ b/src/model/ServiceWrapper.h
@@ -83,6 +83,8 @@ protected:
             WrappedType *previouslyWrapped = m_wrapped;
             __clearConnections__();
             m_wrapped = wrapped;
+            addConnection(QObject::connect(this->wrapped(), &WrappedType::readyChanged,
+                          [this] { emit this->readyChanged(); }));
             facelift::ServiceWrapperBase::setWrapped(*this, m_wrapped);
             bind(wrapped, previouslyWrapped);
             emit this->readyChanged();


### PR DESCRIPTION
ready() property might be changed in runtime due to some conditions, but
ServiceWrapper doesn't reflect those changes, it only emits readyChanged
singal only once when wrapped object was changed. And dependency on
ready property is not working