### PR TITLE
fix msvc linker error - unresolved symbol

### DIFF
--- a/src/ipc/ipc-common/ipc-common.h
+++ b/src/ipc/ipc-common/ipc-common.h
@@ -282,7 +282,7 @@ inline void assignDefaultValue(Type &v)
 }
 
 template<typename AdapterType>
-class FaceliftIPCCommonLib_EXPORT IPCProxyBase : public AdapterType
+class IPCProxyBase : public AdapterType
 {
 
 public:


### PR DESCRIPTION
Fix for following error:
```
error LNK2019: unresolved external symbol "__declspec(dllimport) public: virtual __cdecl facelift::IPCProxyBase<class facelift::ipc::dbus::ObjectRegistry>::~IPCProxyBase<class facelift::ipc::dbus::ObjectRegistry>
```
Remark: Do not export class templates, however you can export instantiated class templates.