### PR TITLE
ServiceWrapper: fix crash

### DIFF
--- a/src/model/ServiceWrapper.h
+++ b/src/model/ServiceWrapper.h
@@ -83,7 +83,7 @@ protected:
             WrappedType *previouslyWrapped = m_wrapped;
             __clearConnections__();
             m_wrapped = wrapped;
-            addConnection(QObject::connect(this->wrapped(), &WrappedType::readyChanged,
+            addConnection(QObject::connect(this->wrapped(), &WrappedType::readyChanged, this,
                           [this] { emit this->readyChanged(); }));
             facelift::ServiceWrapperBase::setWrapped(*this, m_wrapped);
             bind(wrapped, previouslyWrapped);


### PR DESCRIPTION
Add receiver to QObject::Connetion to prevent dereferencing of deleted
object in lambda expression