### PR TITLE
Use double instead of float for generated types

### DIFF
--- a/codegen/facelift/facelift-codegen.py
+++ b/codegen/facelift/facelift-codegen.py
@@ -64,7 +64,7 @@ def getPrimitiveCppType(symbol):
     if symbol.name == 'string':
         return 'QString'
     if symbol.name == 'real':
-        return 'float'
+        return 'double'
     return symbol
 
 def qmlCompatibleType(self):
@@ -108,7 +108,7 @@ def cppTypeFromSymbol(type, isInterfaceType):
         if type.name == 'string':
             return 'QString'
         if type.name == 'real':
-            return 'float'
+            return 'double'
         return type
     elif type.is_list:
         return 'QList<{0}>'.format(cppTypeFromSymbol(type.nested, isInterfaceType))

--- a/src/desktop-dev-tools/ControlWidgets.h
+++ b/src/desktop-dev-tools/ControlWidgets.h
@@ -264,11 +264,11 @@ private:
     QSpinBox *widget = nullptr;
 };
 
-class FloatPropertyWidget : public PropertyWidget<float>
+class DoublePropertyWidget : public PropertyWidget<double>
 {
 
 public:
-    FloatPropertyWidget(float &value, const QString &propertyName, QWidget *parent = nullptr) :
+    DoublePropertyWidget(double &value, const QString &propertyName, QWidget *parent = nullptr) :
         PropertyWidget(value, propertyName, parent)
     {
         widget = new QDoubleSpinBox();
@@ -463,9 +463,9 @@ struct TypeToWidget<int> : public TypeToWidgetBase
 };
 
 template<>
-struct TypeToWidget<float> : public TypeToWidgetBase
+struct TypeToWidget<double> : public TypeToWidgetBase
 {
-    typedef FloatPropertyWidget PanelType;
+    typedef DoublePropertyWidget PanelType;
 };
 
 template<>

--- a/src/desktop-dev-tools/DummyModel.h
+++ b/src/desktop-dev-tools/DummyModel.h
@@ -92,7 +92,7 @@ inline void readJSONSimple<bool>(const QJsonValue &json, bool &value)
 }
 
 template<>
-inline void readJSONSimple<float>(const QJsonValue &json, float &value)
+inline void readJSONSimple<double>(const QJsonValue &json, double &value)
 {
     if (json.isDouble()) {
         value = json.toDouble();

--- a/src/ipc/ipc-common/ipc-serialization.h
+++ b/src/ipc/ipc-common/ipc-serialization.h
@@ -41,19 +41,19 @@
 namespace facelift {
 
 template<>
-struct IPCTypeHandler<float>
+struct IPCTypeHandler<double>
 {
     static void writeDBUSSignature(QTextStream &s)
     {
         s << "d";
     }
 
-    static void write(OutputPayLoad &msg, const float &v)
+    static void write(OutputPayLoad &msg, const double &v)
     {
-        msg.writeSimple((double)v);
+        msg.writeSimple(v);
     }
 
-    static void read(InputPayLoad &msg, float &v)
+    static void read(InputPayLoad &msg, double &v)
     {
         double d;
         msg.readNextParameter(d);

--- a/src/model/FaceliftConversion.h
+++ b/src/model/FaceliftConversion.h
@@ -417,18 +417,18 @@ struct TypeHandler<int> : public TypeHandlerBase
 
 
 template<>
-struct TypeHandler<float> : public TypeHandlerBase
+struct TypeHandler<double> : public TypeHandlerBase
 {
-    typedef float QMLType;
+    typedef double QMLType;
 
-    static QString toString(const float &v)
+    static QString toString(const double &v)
     {
         return QString::number(v);
     }
 
-    static float fromVariant(const QVariant &variant)
+    static double fromVariant(const QVariant &variant)
     {
-        return variant.toFloat();
+        return variant.toDouble();
     }
 };
 


### PR DESCRIPTION
Qt uses double mostly. In QML all reals are stored in double precision.
DBus also works with doubles.
Clients also use double more often than float. So it would be better if
generator will work with double instead of float to avoid conversion
from double to float and prevent precision lost.