### PR TITLE
Fix QML engine reference in nested QML adapters

### DIFF
--- a/codegen/facelift/templates/QMLAdapter.template.cpp
+++ b/codegen/facelift/templates/QMLAdapter.template.cpp
@@ -64,6 +64,10 @@
 {
 }
 
+{{className}}::{{className}}(QObject* parent, QQmlEngine* engine) : facelift::QMLAdapterBase(parent, engine)
+{
+}
+
 void {{className}}::connectProvider({{interfaceName}}& provider)
 {
     facelift::QMLAdapterBase::connectProvider(provider);
@@ -123,7 +127,7 @@ void {{className}}::set{{property}}(const {{property.type.qmlCompatibleType}}& n
 {%- elif property.type.is_interface %}
 {{property.cppType}}QMLAdapter* {{className}}::{{property}}()
 {
-    return facelift::getQMLAdapter(m_provider->{{property}}());
+    return facelift::getQMLAdapter(m_provider->{{property}}(), qmlEngine());
 }
 {% else %}
     {% if property.readonly %}

--- a/codegen/facelift/templates/QMLAdapter.template.h
+++ b/codegen/facelift/templates/QMLAdapter.template.h
@@ -81,6 +81,8 @@ public:
 
     {{className}}(QQmlEngine* engine);
 
+    {{className}}(QObject* parent, QQmlEngine* engine);
+
     void connectProvider({{interfaceName}}& provider);
 
     {% if hasReadyFlags %}

--- a/src/model/QMLAdapter.cpp
+++ b/src/model/QMLAdapter.cpp
@@ -47,6 +47,11 @@ QMLAdapterBase::QMLAdapterBase(QQmlEngine *engine) : QMLAdapterBase(static_cast<
     m_qmlEngine = engine;
 }
 
+QMLAdapterBase::QMLAdapterBase(QObject *parent, QQmlEngine *engine) : QObject(parent)
+    , m_qmlEngine(engine)
+{
+}
+
 InterfaceBase *QMLAdapterBase::provider() {
     Q_ASSERT(m_provider != nullptr);
     qCWarning(LogModel) << "Accessing private provider implementation object";

--- a/src/model/QMLAdapter.h
+++ b/src/model/QMLAdapter.h
@@ -64,6 +64,12 @@ public:
      */
     QMLAdapterBase(QQmlEngine *engine);
 
+    /**
+     *  This constructor is used to create a nested QML adapters
+     *  with valid QQmlEngine reference.
+     */
+    QMLAdapterBase(QObject *parent, QQmlEngine *engine);
+
     Q_PROPERTY(QObject * provider READ provider CONSTANT)
     virtual InterfaceBase *provider();
 
@@ -258,20 +264,19 @@ typename ProviderType::QMLAdapterType *getQMLFrontend(ProviderType *provider)
 }
 
 template<typename ProviderType>
-typename ProviderType::QMLAdapterType *getQMLAdapter(ProviderType *provider)
+typename ProviderType::QMLAdapterType *getQMLAdapter(ProviderType *provider, QQmlEngine *engine = nullptr)
 {
     if (provider == nullptr) {
         return nullptr;
     } else {
         if (provider->m_qmlAdapter == nullptr) {
             // No QML frontend instantiated yet => create one
-            provider->m_qmlAdapter = new typename ProviderType::QMLAdapterType(provider);
+            provider->m_qmlAdapter = new typename ProviderType::QMLAdapterType(provider, engine);
             provider->m_qmlAdapter->connectProvider(*provider);
         }
         return provider->m_qmlAdapter;
     }
 }
-
 
 class FaceliftModelLib_EXPORT ModelListModelBase : public QAbstractListModel
 {

--- a/tests/combined/check_combined.js
+++ b/tests/combined/check_combined.js
@@ -122,6 +122,12 @@ function methods() {
     if (!api.qmlImplementationUsed) {
         api.interfaceProperty.doSomething();
         compare(api.otherInterfaceProperty.otherMethod(OtherEnum.O3), "O3");
+
+        var asyncResult = { answer: 0 };
+        api.otherInterfaceProperty.asyncFunction(function(result) {
+            asyncResult.answer = result;
+        });
+        tryCompare(asyncResult, "answer", 42);
     }
 }
 

--- a/tests/combined/impl/cpp/CombinedTestsCppImplementation.h
+++ b/tests/combined/impl/cpp/CombinedTestsCppImplementation.h
@@ -33,6 +33,7 @@
 #include "tests/combined/CombinedInterfaceImplementationBase.h"
 #include "tests/combined/CombinedInterface2ImplementationBase.h"
 #include "tests/combined/other/OtherInterfaceImplementationBase.h"
+#include <QTimer>
 
 using namespace tests::combined;
 using namespace tests::combined::other;
@@ -48,6 +49,12 @@ public:
         if (oe == OtherEnum::O3)
             return QStringLiteral("O3");
         return QString();
+    }
+
+    void asyncFunction(facelift::AsyncAnswer<int> answer = facelift::AsyncAnswer<int>()) override {
+        QTimer::singleShot(200, this, [answer]() {
+            answer(42);
+        });
     }
 };
 

--- a/tests/combined/interface/other.qface
+++ b/tests/combined/interface/other.qface
@@ -36,6 +36,9 @@ interface OtherInterface {
     int otherInt
     string otherMethod(OtherEnum oe);
     signal otherEvent(OtherStruct os);
+
+    @async: true
+    int asyncFunction();
 }
 
 struct OtherStruct {

--- a/tests/combined/plugin/CombinedTestsPlugin.cpp
+++ b/tests/combined/plugin/CombinedTestsPlugin.cpp
@@ -59,8 +59,8 @@ void CombinedTestsPlugin::registerTypes(const char *uri)
             "/impl/qml/CombinedTestsQmlImplementation.qml", "CombinedInterfaceSingleton");
 #else
     facelift::registerQmlComponent<CombinedInterfaceImplementation>(uri, "CombinedInterfaceAPI");
-
     facelift::registerSingletonQmlComponent<CombinedInterfaceImplementation>(uri, "CombinedInterfaceSingleton");
+    facelift::registerUncreatableQmlComponent<OtherInterfaceImplementation>(uri);
 #endif
 
     facelift::registerSingletonQmlComponent<CombinedInterfaceIPCProxy>(uri, "CombinedInterfaceIPCProxySingleton");


### PR DESCRIPTION
Explicitly pass QML engine reference to nested
adapters during creation since it could not be got
from qmlEngine() global function.