### PR TITLE
Fix QML engine reference in nested QML adapters

### DIFF
--- a/codegen/facelift/templates/QMLAdapter.template.cpp
+++ b/codegen/facelift/templates/QMLAdapter.template.cpp
@@ -123,7 +123,7 @@ void {{className}}::set{{property}}(const {{property.type.qmlCompatibleType}}& n
 {%- elif property.type.is_interface %}
 {{property.cppType}}QMLAdapter* {{className}}::{{property}}()
 {
-    return facelift::getQMLAdapter(m_provider->{{property}}());
+    return facelift::getQMLAdapter(m_provider->{{property}}(), qmlEngine());
 }
 {% else %}
     {% if property.readonly %}

--- a/src/model/QMLAdapter.h
+++ b/src/model/QMLAdapter.h
@@ -258,7 +258,7 @@ typename ProviderType::QMLAdapterType *getQMLFrontend(ProviderType *provider)
 }
 
 template<typename ProviderType>
-typename ProviderType::QMLAdapterType *getQMLAdapter(ProviderType *provider)
+typename ProviderType::QMLAdapterType *getQMLAdapter(ProviderType *provider, QQmlEngine* engine = nullptr)
 {
     if (provider == nullptr) {
         return nullptr;
@@ -267,6 +267,10 @@ typename ProviderType::QMLAdapterType *getQMLAdapter(ProviderType *provider)
             // No QML frontend instantiated yet => create one
             provider->m_qmlAdapter = new typename ProviderType::QMLAdapterType(provider);
             provider->m_qmlAdapter->connectProvider(*provider);
+
+            if (engine) {
+                QQmlEngine::setContextForObject(provider->m_qmlAdapter, engine->rootContext());
+            }
         }
         return provider->m_qmlAdapter;
     }

--- a/tests/combined/check_combined.js
+++ b/tests/combined/check_combined.js
@@ -122,6 +122,12 @@ function methods() {
     if (!api.qmlImplementationUsed) {
         api.interfaceProperty.doSomething();
         compare(api.otherInterfaceProperty.otherMethod(OtherEnum.O3), "O3");
+
+        var asyncResult = { answer: 0 };
+        api.otherInterfaceProperty.asyncFunction(function(result) {
+            asyncResult.answer = result;
+        });
+        tryCompare(asyncResult, "answer", 42);
     }
 }
 

--- a/tests/combined/impl/cpp/CombinedTestsCppImplementation.h
+++ b/tests/combined/impl/cpp/CombinedTestsCppImplementation.h
@@ -33,6 +33,7 @@
 #include "tests/combined/CombinedInterfaceImplementationBase.h"
 #include "tests/combined/CombinedInterface2ImplementationBase.h"
 #include "tests/combined/other/OtherInterfaceImplementationBase.h"
+#include <QTimer>
 
 using namespace tests::combined;
 using namespace tests::combined::other;
@@ -48,6 +49,12 @@ public:
         if (oe == OtherEnum::O3)
             return QStringLiteral("O3");
         return QString();
+    }
+
+    void asyncFunction(facelift::AsyncAnswer<int> answer = facelift::AsyncAnswer<int>()) override {
+        QTimer::singleShot(200, this, [answer]() {
+            answer(42);
+        });
     }
 };
 

--- a/tests/combined/interface/other.qface
+++ b/tests/combined/interface/other.qface
@@ -36,6 +36,9 @@ interface OtherInterface {
     int otherInt
     string otherMethod(OtherEnum oe);
     signal otherEvent(OtherStruct os);
+
+    @async: true
+    int asyncFunction();
 }
 
 struct OtherStruct {

--- a/tests/combined/plugin/CombinedTestsPlugin.cpp
+++ b/tests/combined/plugin/CombinedTestsPlugin.cpp
@@ -59,7 +59,6 @@ void CombinedTestsPlugin::registerTypes(const char *uri)
             "/impl/qml/CombinedTestsQmlImplementation.qml", "CombinedInterfaceSingleton");
 #else
     facelift::registerQmlComponent<CombinedInterfaceImplementation>(uri, "CombinedInterfaceAPI");
-
     facelift::registerSingletonQmlComponent<CombinedInterfaceImplementation>(uri, "CombinedInterfaceSingleton");
 #endif
 


### PR DESCRIPTION
Explicitly set QML context for nested adapters
to be able to get valid QML engine reference via
qmlEngine() global function.