### PR TITLE
Fix QML engine reference in nested QML adapters

### DIFF
--- a/codegen/facelift/templates/QMLAdapter.template.cpp
+++ b/codegen/facelift/templates/QMLAdapter.template.cpp
@@ -123,7 +123,10 @@ void {{className}}::set{{property}}(const {{property.type.qmlCompatibleType}}& n
 {%- elif property.type.is_interface %}
 {{property.cppType}}QMLAdapter* {{className}}::{{property}}()
 {
-    return facelift::getQMLAdapter(m_provider->{{property}}());
+    auto qmlAdapter = facelift::getQMLAdapter(m_provider->{{property}}());
+    if (qmlAdapter != nullptr)
+        qmlAdapter->setParentQMLAdapter(this);
+    return qmlAdapter;
 }
 {% else %}
     {% if property.readonly %}

--- a/examples/AddressBook/models/cpp/advanced/AddressBookCppWithProperties.h
+++ b/examples/AddressBook/models/cpp/advanced/AddressBookCppWithProperties.h
@@ -60,7 +60,7 @@ public:
         m_subService = &m_subInterface;
     }
 
-    // This property is not defined as part of the public interface (IDL), but it can be accessed via the "provider" property
+    // This property is not defined as part of the public interface (QFace file), but it can be accessed via the "provider" property
     Q_PROPERTY(QString privateProperty READ privateProperty CONSTANT)
     QString privateProperty() const
     {

--- a/src/desktop-dev-tools/ControlWidgets.h
+++ b/src/desktop-dev-tools/ControlWidgets.h
@@ -175,11 +175,12 @@ public:
 
     void refreshWidgetFromValue() override
     {
-        auto values = validValues<EnumType>();
-        for (int i = 0; i < values.size(); i++) {
-            if (this->value() == values[i]) {
+        int i = 0;
+        for (auto e : validValues<EnumType>()) {
+            if (this->value() == e) {
                 widget->setCurrentIndex(i);
             }
+            i++;
         }
     }
 
@@ -187,7 +188,7 @@ public:
     {
         QObject::connect(widget, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [this](int) {
                 int index = widget->currentIndex();
-                this->updateValue(validValues<EnumType>()[index]);
+                this->updateValue(*(validValues<EnumType>().begin() + index));
             });
     }
 

--- a/src/model/QMLAdapter.cpp
+++ b/src/model/QMLAdapter.cpp
@@ -73,9 +73,25 @@ void QMLAdapterBase::componentComplete()
    m_provider->setComponentCompleted();
 }
 
+
+void QMLAdapterBase::setParentQMLAdapter(QMLAdapterBase * parentQMLAdapter)
+{
+    // One would expect that this method is not called multiple times with different parentQMLAdapter,
+    // but it actually is, in in-process IPC scenarios. TODO: clarify and fix
+    if (m_parentQMLAdapter == nullptr) {
+        m_parentQMLAdapter = parentQMLAdapter;
+        Q_ASSERT(m_parentQMLAdapter);
+        m_qmlEngine = m_parentQMLAdapter->qmlEngine();
+    }
+}
+
+
 QQmlEngine* QMLAdapterBase::qmlEngine() const
 {
-    return (m_qmlEngine ? m_qmlEngine : ::qmlEngine(this));
+    if (m_qmlEngine == nullptr) {
+        m_qmlEngine = ::qmlEngine(this);
+    }
+    return m_qmlEngine;
 }
 
 

--- a/src/model/QMLAdapter.h
+++ b/src/model/QMLAdapter.h
@@ -81,6 +81,8 @@ public:
 
     QQmlEngine* qmlEngine() const;
 
+    void setParentQMLAdapter(QMLAdapterBase * parentQMLAdapter);
+
 protected:
 
     void connectProvider(InterfaceBase &provider);
@@ -96,8 +98,8 @@ protected:
 
 private:
     InterfaceBase *m_provider = nullptr;
-    QQmlEngine* m_qmlEngine = nullptr;
-
+    mutable QQmlEngine* m_qmlEngine = nullptr;
+    QMLAdapterBase* m_parentQMLAdapter = nullptr;
 };
 
 /*!

--- a/tests/combined/check_combined.js
+++ b/tests/combined/check_combined.js
@@ -122,6 +122,12 @@ function methods() {
     if (!api.qmlImplementationUsed) {
         api.interfaceProperty.doSomething();
         compare(api.otherInterfaceProperty.otherMethod(OtherEnum.O3), "O3");
+
+        var asyncResult = { answer: 0 };
+        api.otherInterfaceProperty.asyncFunction(function(result) {
+            asyncResult.answer = result;
+        });
+        tryCompare(asyncResult, "answer", 42);
     }
 }
 

--- a/tests/combined/impl/cpp/CombinedTestsCppImplementation.h
+++ b/tests/combined/impl/cpp/CombinedTestsCppImplementation.h
@@ -33,6 +33,7 @@
 #include "tests/combined/CombinedInterfaceImplementationBase.h"
 #include "tests/combined/CombinedInterface2ImplementationBase.h"
 #include "tests/combined/other/OtherInterfaceImplementationBase.h"
+#include <QTimer>
 
 using namespace tests::combined;
 using namespace tests::combined::other;
@@ -48,6 +49,12 @@ public:
         if (oe == OtherEnum::O3)
             return QStringLiteral("O3");
         return QString();
+    }
+
+    void asyncFunction(facelift::AsyncAnswer<int> answer = facelift::AsyncAnswer<int>()) override {
+        QTimer::singleShot(200, this, [answer]() {
+            answer(42);
+        });
     }
 };
 

--- a/tests/combined/interface/other.qface
+++ b/tests/combined/interface/other.qface
@@ -36,6 +36,9 @@ interface OtherInterface {
     int otherInt
     string otherMethod(OtherEnum oe);
     signal otherEvent(OtherStruct os);
+
+    @async: true
+    int asyncFunction();
 }
 
 struct OtherStruct {

--- a/tests/combined/plugin/CombinedTestsPlugin.cpp
+++ b/tests/combined/plugin/CombinedTestsPlugin.cpp
@@ -59,7 +59,6 @@ void CombinedTestsPlugin::registerTypes(const char *uri)
             "/impl/qml/CombinedTestsQmlImplementation.qml", "CombinedInterfaceSingleton");
 #else
     facelift::registerQmlComponent<CombinedInterfaceImplementation>(uri, "CombinedInterfaceAPI");
-
     facelift::registerSingletonQmlComponent<CombinedInterfaceImplementation>(uri, "CombinedInterfaceSingleton");
 #endif
 


### PR DESCRIPTION
Explicitly set QML context for nested adapters
to be able to get valid QML engine reference via
qmlEngine() global function.

Change-Id: I4b2a0190b2a65e449d76054176da513f7a33019d