### PR TITLE
Modification of compilation units generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ if(FACELIFT_ENABLE_CODEGEN)
     add_subdirectory(codegen)
 endif()
 
+add_subdirectory(cmake)
 include("cmake/faceliftMacros.cmake")
 
 set(AUTO_UNITY_BUILD ON)
@@ -96,8 +97,10 @@ facelift_export_project(
         cmake/faceliftMacros.cmake
         ${CMAKE_BINARY_DIR}/${PROJECT_NAME}Variables.cmake
         ${CMAKE_BINARY_DIR}/faceliftConfig-codegen.cmake
+        ${CMAKE_BINARY_DIR}/faceliftUnityConfig.cmake
     INSTALLED_FILES
         cmake/faceliftMacros.cmake
         ${CMAKE_BINARY_DIR}/${PROJECT_NAME}Variables.cmake.installed
         ${CMAKE_BINARY_DIR}/faceliftConfig-codegen.installed.cmake
+        ${CMAKE_BINARY_DIR}/faceliftUnityConfig.installed.cmake
 )

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,20 @@
+#project(facelift_codegen VERSION 1.0.0)
+
+#cmake_minimum_required(VERSION 3.1)
+
+include(GNUInstallDirs)    # for standard installation locations
+
+add_executable(unity_generator IMPORTED GLOBAL)
+set_target_properties(unity_generator PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/facelift/unity_generator.py)
+
+set(INSTALLATION_PATH ${CMAKE_INSTALL_BINDIR}/host-tools/facelift)
+
+install(DIRECTORY facelift/ DESTINATION ${INSTALLATION_PATH} USE_SOURCE_PERMISSIONS)
+
+get_target_property(UNITY_GEN_LOCATION unity_generator LOCATION)
+
+file(RELATIVE_PATH UNITY_GEN_RELATIVE_LOCATION /${CMAKE_BINARY_DIR} /${UNITY_GEN_LOCATION})
+configure_file(faceliftUnityConfig.cmake.in ${CMAKE_BINARY_DIR}/faceliftUnityConfig.cmake @ONLY)
+
+file(RELATIVE_PATH UNITY_GEN_RELATIVE_LOCATION /lib/cmake/${PROJECT_NAME} /${INSTALLATION_PATH}/unity_generator.py)
+configure_file(faceliftUnityConfig.cmake.in ${CMAKE_BINARY_DIR}/faceliftUnityConfig.installed.cmake @ONLY)

--- a/cmake/facelift/unity_generator.py
+++ b/cmake/facelift/unity_generator.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+
+#######################################################################
+##
+## Copyright (C) 2019 Luxoft Sweden AB
+##
+## This file is part of the FaceLift project
+##
+## Permission is hereby granted, free of charge, to any person
+## obtaining a copy of this software and associated documentation files
+## (the "Software"), to deal in the Software without restriction,
+## including without limitation the rights to use, copy, modify, merge,
+## publish, distribute, sublicense, and/or sell copies of the Software,
+## and to permit persons to whom the Software is furnished to do so,
+## subject to the following conditions:
+##
+## The above copyright notice and this permission notice shall be
+## included in all copies or substantial portions of the Software.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+## EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+## MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+## NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+## BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+## ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+## CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+## SOFTWARE.
+##
+## SPDX-License-Identifier: MIT
+##
+#######################################################################
+
+import os.path
+import sys
+import json
+import click
+
+cmake_separator = ";"
+internal_separator = "#"
+
+unit_cache_file_format = "cached_values_{}.json"
+unit_filename_format = "{}_unity_{}.cpp"
+unit_include_limit = 5
+unit_size_limit = 500000
+
+
+class UnitCache:
+    def __init__(self, units):
+        self.units = units
+
+    def file_list(self):
+        return [file for unit in self.units for file in unit.file_list]
+
+    def last_unit(self):
+        if len(self.units):
+            return max(self.units, key=lambda u: u.unit_index)
+        self.units.append(Unit())
+        return self.last_unit()
+
+    def add_files(self, files):
+        unit = self.last_unit()
+        for file in files:
+            file_size = os.path.getsize(file) if os.path.isfile(file) else 0
+            if not unit.can_add_file(file_size):
+                previous_index = unit.unit_index
+                unit = Unit(unit_index=previous_index + 1)
+                self.units.append(unit)
+            unit.add_file(file, file_size)
+
+    def remove_files(self, files):
+        for unit in self.units:
+            unit.remove_files(files)
+        self.units[:] = [unit for unit in self.units if len(unit.file_list) > 0]
+
+    @classmethod
+    def from_json(cls, input: dict):
+        units = list(map(Unit.from_json, input["units"]))
+        return cls(units)
+
+
+class Unit:
+    def __init__(self, file_list = None, unit_index = 1):
+        self.file_list = file_list if file_list is not None else []
+        self.unit_index = unit_index
+        self.size = 0
+        self.update_size()
+
+    def add_file(self, file, file_size):
+        self.file_list.append(file)
+        self.size += file_size
+
+    def remove_files(self, files):
+        self.file_list[:] = [file for file in self.file_list if file not in files]
+        self.update_size()
+
+    def sort_files(self):
+        self.file_list.sort()
+
+    def update_size(self):
+        self.size = 0
+        for file in self.file_list:
+            if os.path.exists(file) and os.path.isfile(file):
+                self.size += os.path.getsize(file) if os.path.isfile(file) else 0
+
+    def can_add_file(self, file_size):
+
+        # ok to add file if there no files
+        if len(self.file_list) == 0:
+            return True
+        return len(self.file_list) < unit_include_limit and file_size + self.size < unit_size_limit
+
+    @classmethod
+    def from_json(cls, input: dict):
+        return cls(file_list=input["file_list"], unit_index=input["unit_index"])
+
+
+class UnityGenerator:
+    @classmethod
+    def generate(cls, cache: UnitCache, target_folder, target_name):
+        units = []
+        for unit in cache.units:
+            unit_path = UnityGenerator.generate_unit(unit, target_folder, target_name)
+            file_list = internal_separator.join(unit.file_list)
+            units.append(internal_separator.join([unit_path, file_list]))
+
+        return units
+
+    @classmethod
+    def generate_unit(cls, unit: Unit, target_folder, target_name):
+        def write_file():
+            with open(unit_path, 'w') as file:
+                file.write(file_content)
+
+        unit.sort_files()
+        file_content = ""
+        for file in unit.file_list:
+            file_content += "#include \"{}\"\n".format(file)
+
+        unit_path = os.path.join(target_folder, unit_filename_format.format(target_name, unit.unit_index))
+
+        if os.path.exists(unit_path) and os.path.isfile(unit_path):
+            file = open(unit_path, 'r')
+            if file.read() != file_content:
+                write_file()
+        else:
+            write_file()
+
+        return unit_path
+
+
+def run_generation(files, target_folder, target_name):
+
+    cache = UnitCache([])
+
+    cache_path = os.path.join(target_folder, unit_cache_file_format.format(target_name))
+    if os.path.exists(cache_path) and os.path.isfile(cache_path):
+        with open(cache_path) as file:
+            cache = UnitCache.from_json(json.load(file))
+
+    cached_files = cache.file_list()
+
+    to_remove = []
+    for file in cached_files:
+        if file not in files:
+            to_remove.append(file)
+
+    to_add = []
+    for file in files:
+        if file not in cached_files:
+            to_add.append(file)
+
+    if len(to_remove):
+        cache.remove_files(to_remove)
+    if len(to_add):
+        cache.add_files(to_add)
+
+    generated_units = UnityGenerator.generate(cache, target_folder, target_name)
+    cmake_string = cmake_separator.join(generated_units)
+    sys.stdout.write(cmake_string)
+
+    with open(cache_path, 'w') as file:
+        json.dump(cache, file, default=lambda c: c.__dict__)
+
+
+@click.command()
+@click.option('--output')
+@click.option('--target_name')
+@click.option('--size_limit', type=int)
+@click.option('--separator', type=str)
+@click.argument('files', nargs=-1)
+def generate_units(files, output, target_name, size_limit = None, separator = None):
+
+    if size_limit is not None:
+        global unit_size_limit
+        unit_size_limit = size_limit
+
+    if separator is not None:
+        global internal_separator
+        internal_separator = separator
+
+    run_generation(files, output, target_name)
+
+
+if __name__ == '__main__':
+    generate_units()

--- a/cmake/faceliftMacros.cmake
+++ b/cmake/faceliftMacros.cmake
@@ -48,69 +48,34 @@ function(facelift_add_unity_files TARGET_NAME VAR_NAME)
         list(SORT FILE_LIST)
     endif()
 
-    set(AGGREGATED_FILE_LIST "")
+    set(INTERNAL_SEPARATOR "#")
+    set(AGGREGATED_UNIT_FILE_LIST "")
+    set(COMPLETE_FILE_LIST "")
+    if(NOT "${FACELIFT_CACHED_LIST_${TARGET_NAME}}" STREQUAL "${FILE_LIST}")
+        get_target_property(UNITY_LOCATION unity_generator LOCATION)
+        execute_process(COMMAND ${UNITY_LOCATION} --output ${CMAKE_CURRENT_BINARY_DIR} --target_name ${TARGET_NAME} ${FILE_LIST}
+                        OUTPUT_VARIABLE COMPLETE_FILE_LIST)
+        set(FACELIFT_CACHED_COMPLETE_FILE_LIST_${TARGET_NAME} "${COMPLETE_FILE_LIST}" CACHE INTERNAL "Store files")
+    else()
+        set(COMPLETE_FILE_LIST ${FACELIFT_CACHED_COMPLETE_FILE_LIST_${TARGET_NAME}})
+    endif()
 
-    list(LENGTH FILE_LIST REMAINING_FILE_COUNT)
+    foreach(SOURCES_IN_UNIT_LIST ${COMPLETE_FILE_LIST})
+            string(REPLACE ${INTERNAL_SEPARATOR} ";" SOURCES_IN_UNIT_LIST ${SOURCES_IN_UNIT_LIST})
 
-    while(${REMAINING_FILE_COUNT} GREATER 0)
+            # first file is unit file path
+            list(GET SOURCES_IN_UNIT_LIST 0 UNIT_PATH)
+            list(REMOVE_AT SOURCES_IN_UNIT_LIST 0)
 
-        list(LENGTH FILE_LIST LIST_LENGTH)
+            set_source_files_properties(${UNIT_PATH} PROPERTIES OBJECT_DEPENDS "${SOURCES_IN_UNIT_LIST}")
+            list(APPEND AGGREGATED_UNIT_FILE_LIST ${UNIT_PATH})
+    endforeach()
 
-        if(NOT LIST_LENGTH)
-            break()
-        endif()
+    set(FACELIFT_CACHED_LIST_${TARGET_NAME} "${FILE_LIST}" CACHE INTERNAL "stored file list for the target")
 
-        math(EXPR FILE_INDEX "${FILE_INDEX}+1")
-
-        set(REMAINING_FILE_COUNT_PER_UNIT ${UNITY_BUILD_MAX_FILE_COUNT})
-
-        unset(FILES)
-        set(UNITY_FILE_SIZE 0)
-        while((${UNITY_BUILD_MAX_FILE_SIZE} GREATER ${UNITY_FILE_SIZE}) AND (${REMAINING_FILE_COUNT} GREATER 0) AND (${REMAINING_FILE_COUNT_PER_UNIT} GREATER 0))
-            list(GET FILE_LIST 0 FILE)
-            list(REMOVE_AT FILE_LIST 0)
-            list(APPEND FILES ${FILE})
-
-            if(EXISTS ${FILE})
-                file(READ "${FILE}" TMP_FILE_CONTENT)
-            else()
-                unset(TMP_FILE_CONTENT)
-            endif()
-            string(LENGTH "${TMP_FILE_CONTENT}" FILE_SIZE)
-
-            math(EXPR UNITY_FILE_SIZE "${UNITY_FILE_SIZE}+${FILE_SIZE}")
-            math(EXPR REMAINING_FILE_COUNT "${REMAINING_FILE_COUNT}-1")
-            math(EXPR REMAINING_FILE_COUNT_PER_UNIT "${REMAINING_FILE_COUNT_PER_UNIT}-1")
-        endwhile()
-
-        # Generate an aggregator unit content
-        set(FILE_CONTENT "")
-        set(FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_unity_${FILE_INDEX}.cpp)
-        foreach(SRC_FILE ${FILES})
-            set(FILE_CONTENT "${FILE_CONTENT}#include \"${SRC_FILE}\"\n")
-        endforeach()
-
-        # To avoid unnecessary recompiles, check if it is really necessary to rewrite the unity file
-        if(EXISTS ${FILE_NAME})
-            file(READ ${FILE_NAME} OLD_FILE_CONTENT)
-        else()
-            unset(OLD_FILE_CONTENT)
-        endif()
-
-        if(NOT "${OLD_FILE_CONTENT}" STREQUAL "${FILE_CONTENT}")
-            file(WRITE ${FILE_NAME} ${FILE_CONTENT})
-        endif()
-
-        set_source_files_properties(${FILE_NAME} PROPERTIES OBJECT_DEPENDS "${FILES}")
-
-        list(APPEND AGGREGATED_FILE_LIST ${FILE_NAME})
-
-    endwhile()
-
-    set(${VAR_NAME} ${AGGREGATED_FILE_LIST} ${NON_UNITY_FILE_LIST} PARENT_SCOPE)
+    set(${VAR_NAME} ${AGGREGATED_UNIT_FILE_LIST} ${NON_UNITY_FILE_LIST} PARENT_SCOPE)
 
 endfunction()
-
 
 # Copy the content of FOLDER_SOURCE into FOLDER_DESTINATION, without overwriting files which already have the same content
 function(facelift_synchronize_folders FOLDER_SOURCE FOLDER_DESTINATION)

--- a/cmake/faceliftUnityConfig.cmake.in
+++ b/cmake/faceliftUnityConfig.cmake.in
@@ -1,0 +1,4 @@
+if (NOT TARGET unity_generator)
+    add_executable(unity_generator IMPORTED GLOBAL)
+    set_target_properties(unity_generator PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_LIST_DIR}/@UNITY_GEN_RELATIVE_LOCATION@)
+endif()


### PR DESCRIPTION
Modified way of generating unity files to keep same content and timestamp
as long as possible to avoid recompilation of units.
New approach generates only units if new files are added
or files are removed.