### PR TITLE
fix compile error when printing empty struct

### DIFF
--- a/tests/manual/interface/test.qface
+++ b/tests/manual/interface/test.qface
@@ -94,6 +94,9 @@ struct TestStruct {
     int anInt
 }
 
+struct EmptyStruct {
+}
+
 enum TestEnum {
     E1,
     E2,


### PR DESCRIPTION
- additionaly adjusted template code to use fold expression
  add unit test for empty struct printing
- removed not needed extra function for empty tuples,
  because calling the function with an empty tuple
  the pack expension will become this: " (void)expander{0};"
  So no template code like "std::get<>(t)" instantiated at all.