### PR TITLE
Add simple HTML documentation generation

### DIFF
--- a/codegen/facelift/templates/documentation/Default.template.html
+++ b/codegen/facelift/templates/documentation/Default.template.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,500,700&display=swap" rel="stylesheet">
+
+    <style type="text/css">
+        body {
+            font-family: 'Roboto Mono', monospace;
+        }
+    </style>
+
+    <title>{% block title %}{% endblock %}</title>
+  </head>
+  <body>
+    <!-- As a heading -->
+    <nav class="navbar navbar-light bg-light">
+        <span class="navbar-brand mb-0 h1">
+            Facelift Generated Interface Documentation
+        </span>
+    </nav>
+    
+    <div class="container">
+        <div class="mt-5"></div>
+
+        {% block content %}{% endblock %}
+    </div>
+
+
+    <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/codegen/facelift/templates/documentation/Enum.template.html
+++ b/codegen/facelift/templates/documentation/Enum.template.html
@@ -1,0 +1,39 @@
+{% extends "documentation/Default.template.html" %}
+
+{% block title %}
+Facelift Generated Documentation - {{ enum.name }}
+{% endblock %}
+
+{% block content %}
+        <h5>
+            <span class="badge badge-secondary">{{ module.name }}</span>
+            {{ enum.name }}
+        </h5>
+        <div class="mt-3"></div>
+        {# Clear doc as it may be polluted by global scope #}
+        {% set doc = None %}
+        {% set doc = enum.comment|parse_doc %}
+        {% if doc != None %}
+        {{ doc.brief | join(' ') }}
+        {% else %}
+        <div class="text-muted">No documentation found</div>
+        {% endif %}
+
+        <div class="mt-3"></div>
+        <ul class="list-group">
+        {% for element in enum.members %}
+            <li class="list-group-item">
+                {{ element.type }} {{ element.name }} = {{ element.value }}
+                <div class="mt-1"></div>
+                {# Clear doc as it may be polluted by global scope #}
+                {% set doc = None %}
+                {% set doc = element.comment|parse_doc %}
+                {% if doc != None %}
+                {{ doc.brief | join(' ') }}
+                {% else %}
+                <div class="text-muted">No documentation found</div>
+                {% endif %}
+            </li>
+        {% endfor %}
+        </ul>
+{% endblock %}

--- a/codegen/facelift/templates/documentation/Index.template.html
+++ b/codegen/facelift/templates/documentation/Index.template.html
@@ -1,0 +1,99 @@
+{% extends "documentation/Default.template.html" %}
+
+{% block title %}
+Facelift Generated Documentation - All Modules
+{% endblock %}
+
+{% block content %}
+    <h5>Modules</h5>
+    {% for module in system.modules %}
+    {% set module_path = ".".join(module.name_parts) %}
+    <div class="card">
+        <div class="card-body">
+            <h6 class="card-title">
+                <a href="{{ module_path }}.Module.html">
+                    {{ module.name }}
+                </a>
+            </h6>
+
+            <h7>
+                Interfaces 
+                <span class="badge badge-secondary">
+                    {{ module.interfaces | length }}
+                </span>
+            </h7>
+
+            <ul>
+            {% for interface in module.interfaces %}
+                <li>
+                    <a href="{{ module_path }}.{{interface.name}}.Interface.html">
+                        {{ interface.name }}
+                    </a>
+                </li>
+            {% endfor %}
+            </ul>
+
+            <h7>Structs <span class="badge badge-secondary">{{ module.structs | length }}</span></h7>
+
+            <ul>
+            {% if module.structs|length == 0 %}
+                <div class="text-muted">No structs found</div>
+            {% endif %}
+            {% for struct in module.structs %}
+                <li>
+                    <a href="{{ module_path }}.{{struct.name}}.Struct.html">
+                        {{ struct.name }}
+                    </a>
+                </li>
+            {% endfor %}
+            </ul>
+
+            <h7>Enums <span class="badge badge-secondary">{{ module.enums | length }}</span></h7>
+
+            <ul>
+                {% if module.enums|length == 0 %}
+                    <div class="text-muted">No enums found</div>
+                {% endif %}
+                {% for enum in module.enums %}
+                    <li>
+                        <a href="{{ module_path }}.{{enum.name}}.Enum.html">
+                            {{ enum.name }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+
+    {% endfor %}
+
+    <div class="mt-5"></div>
+
+    <h6>QFace Input Files</h6>
+    <ul>
+        {% if qface_input_list|length == 0 %}
+            <div class="text-muted">No input files found</div>
+        {% endif %}
+        {% for input in qface_input_list %}
+            <li>
+                <a href="file://{{ input }}">{{ input }}</a>
+            </li>
+        {% endfor %}
+    </ul>
+    
+    <div class="mt-5"></div>
+
+    <h6>QFace Dependency Files</h6>
+    <ul>
+        {% if qface_dependency_list|length == 0 %}
+            <div class="text-muted">No dependency files found</div>
+        {% endif %}
+        {% for dependency in qface_dependency_list %}
+            <li>
+                <a href="file://{{ dependency }}">{{ dependency }}</a>
+            </li>
+        {% endfor %}
+    </ul>
+    
+    <div class="mt-5"></div>
+{% endblock %}

--- a/codegen/facelift/templates/documentation/Interface.template.html
+++ b/codegen/facelift/templates/documentation/Interface.template.html
@@ -1,0 +1,126 @@
+{% extends "documentation/Default.template.html" %}
+
+{% block title %}
+Facelift Generated Documentation - {{ interface.name }}
+{% endblock %}
+
+{% block content %}
+        {# Header of Interface #}
+        <h5>
+            <span class="badge badge-secondary">{{ module.name }}</span>
+            {{ interface.name }}
+        </h5>
+        <div class="mt-3"></div>
+        {# Clear doc as it may be polluted by global scope #}
+        {% set doc = None %}
+        {% set doc = interface.comment|parse_doc %}
+        {% if doc != None %}
+        {{ doc.brief | join(' ') }}
+        {% else %}
+        <div class="text-muted">No documentation found</div>
+        {% endif %}
+
+        {# Properties #}
+        <div class="mt-3"></div>
+        <h6>Properties</h6>
+        {% if interface.properties|length == 0 %}
+        <div class="text-muted">No operations found</div>
+        {% endif %}
+        <ul class="list-group">
+        {% for element in interface.properties %}
+        
+        {% set html_suffix = ".Struct.html" %}
+        {% if element.type.is_interface %}
+            {% set html_suffix = ".Interface.html" %}
+        {% elif element.type.is_enum %}
+            {% set html_suffix = ".Enum.html" %}
+        {% endif %}
+
+        {% set readonly_suffix = "" %}
+        {% if element.readonly %}
+            {% set readonly_suffix = "<div class=\"text-muted\">readonly</div>" %}
+        {% endif %}
+
+        <li class="list-group-item">
+        {{ readonly_suffix }}
+        {% if element.type.is_list or element.type.is_model %}
+            {{ element.type }}&lt;<a href='{{ element.type.nested.name }}{{html_suffix}}'><b>{{ element.type.nested.name }}</b></a>&gt; {{ element.name }}
+        {% elif element.type.is_primitive %}
+            {{ element.type }} {{ element.name }}
+        {% else %}
+            <a href="{{ element.type.name }}{{html_suffix}}"><b>{{ element.type }}</b></a>
+            {{ element.name }}
+        {% endif %}
+        <div class="mt-1"></div>
+        {# Clear doc as it may be polluted by global scope #}
+        {% set doc = None %}
+        {% set doc = element.comment|parse_doc %}
+        {% if doc != None %}
+        {{ doc.brief | join(' ') }}
+        {% else %}
+        <div class="text-muted">No documentation found</div>
+        {% endif %}
+        {% endfor %}
+        </li>
+        </ul>
+
+        {# Operations #}
+        <div class="mt-3"></div>
+        <h6>Operations</h6>
+        {% if interface.operations|length == 0 %}
+        <div class="text-muted">No operations found</div>
+        {% endif %}
+        <ul class="list-group">
+        {% for element in interface.operations %}
+            <li class="list-group-item">
+            {{ element.type }} {{ element.name }}(
+                {%- set comma = joiner(", ") -%}
+                {%- for parameter in element.parameters -%}
+                    {{ comma() }}
+                    {% if parameter.type.is_list or parameter.type.is_model %}
+                    {{ '%s&lt;<a href="{{ parameter.type.nested.name }}.Struct.html"><b>%s</b></a>&gt;' % (parameter.type, parameter.type.nested.name) }} {{ parameter.name }}
+                    {% elif parameter.type.is_primitive %}
+                        {{ parameter.type.name }} {{ parameter.name }}
+                    {% else %}
+                        <a href="{{ parameter.type.name }}.Struct.html"><b>{{ parameter.type }}</b></a>
+                        {{ parameter.name }}
+                    {% endif %}
+                {%- endfor -%}
+            )
+                <div class="mt-1"></div>
+            {# Clear doc as it may be polluted by global scope #}
+            {% set doc = None %}
+            {% set doc = element.comment|parse_doc %}
+            {% if doc != None %}
+            {{ doc.brief | join(' ') }}
+            {% else %}
+                <div class="text-muted">No documentation found</div>
+            {% endif %}
+            {% endfor %}
+            </li>
+        </ul>
+
+        {# Signals #}
+        <div class="mt-3"></div>
+        <h6>Signals</h6>
+        {% if interface.signals|length == 0 %}
+        <div class="text-muted">No signals found</div>
+        {% endif %}
+        <ul class="list-group">
+        {% for element in interface.signals %}
+            <li class="list-group-item">
+                void {{ element.name }}()
+                <div class="mt-1"></div>
+            {# Clear doc as it may be polluted by global scope #}
+            {% set doc = None %}
+            {% set doc = element.comment|parse_doc %}
+            {% if doc != None %}
+            {{ doc.brief | join(' ') }}
+            {% else %}
+                <div class="text-muted">No documentation found</div>
+            {% endif %}
+            {% endfor %}
+            </li>
+        </ul>
+        <div class="mt-5"></div>
+{% endblock %}

--- a/codegen/facelift/templates/documentation/Module.template.html
+++ b/codegen/facelift/templates/documentation/Module.template.html
@@ -1,0 +1,61 @@
+
+{% extends "documentation/Default.template.html" %}
+
+{% block title %}
+Facelift Generated Documentation - All Modules
+{% endblock %}
+
+{% block content %}
+    <h5>Module</h5>
+    <div class="card">
+        <div class="card-body">
+            <h5 class="card-title">
+                    <span class="badge badge-secondary">
+                        {{ module.name }}
+                    </span>
+            </h5>
+
+            <h7>
+                Interfaces 
+                <span class="badge badge-secondary">
+                    {{ module.interfaces | length }}
+                </span>
+            </h7>
+
+            <ul>
+            {% if module.interfaces|length == 0 %}
+                <div class="text-muted">No interfaces found</div>
+            {% endif %}
+            {% for interface in module.interfaces %}
+                <li>
+                    <a href="{{ interface.name }}.Interface.html">
+                        {{ interface.name }}
+                    </a>
+                </li>
+            {% endfor %}
+            </ul>
+
+            <h7>Structs <span class="badge badge-secondary">{{ module.structs | length }}</span></h7>
+            <ul>
+            {% if module.structs|length == 0 %}
+                <div class="text-muted">No structs found</div>
+            {% endif %}
+            {% for struct in module.structs %}
+                <li>{{ struct.name }}</li>
+            {% endfor %}
+            </ul>
+
+            <h7>Enums <span class="badge badge-secondary">{{ module.enums | length }}</span></h7>
+            <ul>
+            {% if module.enums|length == 0 %}
+                <div class="text-muted">No enums found</div>
+            {% endif %}
+            {% for enum in module.enums %}
+                <li>{{ enum.name }}</li>
+            {% endfor %}
+            </ul>
+        </div>
+    </div>
+
+    <div class="mt-5"></div>
+{% endblock %}

--- a/codegen/facelift/templates/documentation/Struct.template.html
+++ b/codegen/facelift/templates/documentation/Struct.template.html
@@ -1,0 +1,60 @@
+{% extends "documentation/Default.template.html" %}
+
+{% block title %}
+Facelift Generated Documentation - {{ struct.name }}
+{% endblock %}
+
+{% block content %}
+        <h5>
+            <span class="badge badge-secondary">{{ module.name }}</span>
+            {{ struct.name }}
+        </h5>
+        
+        <div class="mt-3"></div>
+
+        {# Clear doc as it may be polluted by global scope #}
+        {% set doc = None %}
+        {% set doc = struct.comment|parse_doc %}
+        {% if doc != None %}
+        {{ doc.brief | join(' ') }}
+        {% else %}
+        <div class="text-muted">No documentation found</div>
+        {% endif %}
+
+        <div class="mt-3"></div>
+        
+        <ul class="list-group">
+        {% for element in struct.fields %}
+
+            {% set readonly_suffix = "" %}
+            {% if element.readonly %}
+                {% set readonly_suffix = "<div class=\"text-muted\">readonly</div>" %}
+            {% endif %}
+
+            <li class="list-group-item">
+            {{ readonly_suffix }}
+            {% if element.type.is_list or element.type.is_model %}
+                {{ '%s&lt;<a href="{{ element.type.nested.name }}.Struct.html"><b>%s</b></a>&gt;' % (element.type, element.type.nested.name) }} {{ element.name }}
+            {% elif element.type.is_primitive %}
+                {{ element.type }} {{ element.name }}
+            {% elif element.type.is_enum %}
+                <a href="{{ element.type.name }}.Enum.html"><b>{{ element.type }}</b></a>
+                {{ element.name }}
+            {% else %}
+                <a href="{{ element.type.name }}.Struct.html"><b>{{ element.type }}</b></a>
+                {{ element.name }}
+            {% endif %}
+                <div class="mt-1"></div>
+            {# Clear doc as it may be polluted by global scope #}
+            {% set doc = None %}
+            {% set doc = element.comment|parse_doc %}
+            {% if doc != None %}
+            {{ doc.brief | join(' ') }}
+            {% else %}
+                <div class="text-muted">No documentation found</div>
+            {% endif %}
+            </li>
+        {% endfor %}
+        </ul>
+        <div class="mt-5"></div>
+{% endblock %}

--- a/examples/AddressBook/interface/addressbook.qface
+++ b/examples/AddressBook/interface/addressbook.qface
@@ -35,6 +35,9 @@ interface SubInterface {
     void doSomething();
 }
 
+/**
+@brief A representation of an address book that stores a list of contacts
+*/
 @ipc-sync: true
 @qml-implementation: true
 interface AddressBook {
@@ -56,6 +59,9 @@ interface AddressBook {
 
 }
 
+/**
+@brief A collection of details of a known person or contact
+*/
 @qml-component: true
 struct Contact {
     int idx
@@ -64,6 +70,9 @@ struct Contact {
     ContactType type
 }
 
+/**
+@brief The type of relationship binding the user and the contact
+*/
 enum ContactType {
     Friend,
     Family,


### PR DESCRIPTION
Generates documentation in HTML format under each "system", e.g.:

![image](https://user-images.githubusercontent.com/468482/71909777-87326800-3125-11ea-8fa3-abc2fa006ddb.png)

