### PR TITLE
Replace load by safe_load

### DIFF
--- a/codegen/facelift/facelift-codegen.py
+++ b/codegen/facelift/facelift-codegen.py
@@ -39,7 +39,7 @@ import qface
 
 here = Path(__file__).dirname()
 
-logging.config.dictConfig(yaml.load(open(here / 'facelift-log.yaml')))
+logging.config.dictConfig(yaml.safe_load(open(here / 'facelift-log.yaml')))
 log = logging.getLogger(__name__)
 
 generateAsyncProxy = False


### PR DESCRIPTION
- In gentoo linux yaml.load usage blocked because of
  https://bugs.gentoo.org/659348. Replace it by yaml.safe_load