### PR TITLE
Introduce FACELIFT_DISABLE_PROPERTY_VERIFIER env var

### DIFF
--- a/codegen/facelift/templates/Service.template.cpp
+++ b/codegen/facelift/templates/Service.template.cpp
@@ -50,11 +50,13 @@ constexpr const char* {{interfaceName}}::FULLY_QUALIFIED_INTERFACE_NAME;
     init(FULLY_QUALIFIED_INTERFACE_NAME);
 
 #ifdef QT_DEBUG
-    QObject::connect(this, &InterfaceBase::componentCompleted, this, [this]() {
-    {% for property in interface.properties %}
-        facelift::checkProperty({{property.name}}Property(), "{{property.name}}");
-    {% endfor %}
-    });
+    if (facelift::PropertyVerifier::isEnabled()) {
+        QObject::connect(this, &InterfaceBase::componentCompleted, this, [this]() {
+        {% for property in interface.properties %}
+            facelift::PropertyVerifier::checkProperty({{property.name}}Property(), "{{property.name}}");
+        {% endfor %}
+        });
+    }
 #endif
 
 }

--- a/src/model/PropertyVerifier.cpp
+++ b/src/model/PropertyVerifier.cpp
@@ -32,7 +32,12 @@
 
 namespace facelift {
 
-void onUnexpectedChangeSignalTriggered()
+bool PropertyVerifier::isEnabled() {
+    static bool isDisabled = qEnvironmentVariableIsSet("FACELIFT_DISABLE_PROPERTY_VERIFIER");
+    return !isDisabled;
+}
+
+void PropertyVerifier::onUnexpectedChangeSignalTriggered()
 {
     // uncomment the following line to make unexpected signals fatal
 //    qFatal("Fatal error");


### PR DESCRIPTION
This variable can be used to disable the property verifier in debug
mode.