### PR TITLE
Cleanup

### DIFF
--- a/src/ipc/local/LocalIPCProxy.h
+++ b/src/ipc/local/LocalIPCProxy.h
@@ -160,7 +160,7 @@ public:
     template<typename Type>
     using IPCProxyType = typename Type::IPCLocalProxyType;
 
-    LocalIPCProxy(QObject *parent = nullptr) : IPCProxyBase<InterfaceType>(parent), LocalIPCProxyBase(m_ipcBinder), m_ipcBinder(*this)
+    LocalIPCProxy(QObject *parent = nullptr) : IPCProxyBase<InterfaceType>(parent), LocalIPCProxyBase(*this), m_ipcBinder(*this)
     {
         m_ipcBinder.setInterfaceName(InterfaceType::FULLY_QUALIFIED_INTERFACE_NAME);
         m_ipcBinder.setHandler(this);

--- a/src/ipc/local/LocalIPCProxy.h
+++ b/src/ipc/local/LocalIPCProxy.h
@@ -160,7 +160,7 @@ public:
     template<typename Type>
     using IPCProxyType = typename Type::IPCLocalProxyType;
 
-    LocalIPCProxy(QObject *parent = nullptr) : IPCProxyBase<InterfaceType>(parent), LocalIPCProxyBase(*this), m_ipcBinder(*this)
+    LocalIPCProxy(QObject *parent = nullptr) : IPCProxyBase<InterfaceType>(parent), LocalIPCProxyBase(m_ipcBinder), m_ipcBinder(*this)
     {
         m_ipcBinder.setInterfaceName(InterfaceType::FULLY_QUALIFIED_INTERFACE_NAME);
         m_ipcBinder.setHandler(this);

--- a/src/model/QMLModel.h
+++ b/src/model/QMLModel.h
@@ -83,7 +83,6 @@ public:
 
     const QString &implementationID() const
     {
-        return m_implementationID;
         Q_ASSERT(m_interface != nullptr);
         return m_interface->implementationID();
     }


### PR DESCRIPTION
Remove from the method an incorrect return that was present twice and returned an incorrect value