### PR TITLE
Check copy-assignment operator

### DIFF
--- a/codegen/facelift/templates/Struct.template.cpp
+++ b/codegen/facelift/templates/Struct.template.cpp
@@ -114,7 +114,9 @@ const {{struct}}::FieldNames {{struct}}::FIELD_NAMES = { {
 
 {{struct.name}}& {{struct.name}}::operator=(const {{struct.name}} &right)
 {
-    copyFrom(right);
+    if (this != &right) {
+        copyFrom(right);
+    }
     return *this;
 }
 

--- a/src/ipc/dbus/DBusIPCMessage.cpp
+++ b/src/ipc/dbus/DBusIPCMessage.cpp
@@ -46,7 +46,9 @@ DBusIPCMessage::DBusIPCMessage(const DBusIPCMessage &other) : m_message(other.m_
 
 DBusIPCMessage &DBusIPCMessage::operator=(const DBusIPCMessage &other)
 {
-    m_message = other.m_message;
+    if (this != &other) {
+        m_message = other.m_message;
+    }
     return *this;
 }
 

--- a/src/ipc/local/LocalIPC.h
+++ b/src/ipc/local/LocalIPC.h
@@ -86,8 +86,10 @@ public:
 
     LocalIPCMessage &operator=(const LocalIPCMessage &other)
     {
-        m_data = other.m_data;
-        copyRequestMessage(other);
+        if (this != &other) {
+            m_data = other.m_data;
+            copyRequestMessage(other);
+        }
         return *this;
     }
 

--- a/src/model/AsyncAnswer.h
+++ b/src/model/AsyncAnswer.h
@@ -129,7 +129,9 @@ public:
 
     AsyncAnswer &operator=(const AsyncAnswer &other)
     {
-        m_master = other.m_master;
+        if (this != &other) {
+            m_master = other.m_master;
+        }
         return *this;
     }
 


### PR DESCRIPTION
Check copy-assignment operator is expected to perform no action on self-assignment, and to return the lhs by reference