### PR TITLE
Add CMake LINK_DEPENDS_NO_SHARED property as a parameter to the Facel…

### DIFF
--- a/cmake/faceliftMacros.cmake
+++ b/cmake/faceliftMacros.cmake
@@ -483,7 +483,7 @@ endmacro()
 
 function(facelift_add_library TARGET_NAME)
 
-    _facelift_parse_target_arguments("SYSTEM;STATIC;SHARED;OBJECT;MODULE;MONOLITHIC_SUPPORTED;NO_MONOLITHIC" ""
+    _facelift_parse_target_arguments("SYSTEM;STATIC;SHARED;OBJECT;MODULE;MONOLITHIC_SUPPORTED;NO_MONOLITHIC" "LINK_DEPENDS_NO_SHARED"
         "HEADERS_NO_INSTALL;HEADERS_GLOB_NO_INSTALL;HEADERS_GLOB_RECURSE_NO_INSTALL;PUBLIC_HEADER_BASE_PATH;MONOLITHIC_LINK_LIBRARIES"
         ${ARGN}
     )
@@ -496,6 +496,10 @@ function(facelift_add_library TARGET_NAME)
     endif()
 
     list(APPEND ARGUMENT_LINK_LIBRARIES ${ARGUMENT_MONOLITHIC_LINK_LIBRARIES})
+
+    if (DEFINED ARGUMENT_LINK_DEPENDS_NO_SHARED)
+        set(CMAKE_LINK_DEPENDS_NO_SHARED ${ARGUMENT_LINK_DEPENDS_NO_SHARED})
+    endif()
 
     unset(__INTERFACE)
     if(ARGUMENT_INTERFACE)
@@ -695,8 +699,12 @@ endfunction()
 
 
 function(facelift_add_executable TARGET_NAME)
-    _facelift_parse_target_arguments("" "" "" ${ARGN})
+    _facelift_parse_target_arguments("" "LINK_DEPENDS_NO_SHARED" "" ${ARGN})
     _facelift_add_target_start(${TARGET_NAME})
+    if (DEFINED ARGUMENT_LINK_DEPENDS_NO_SHARED)
+        set(CMAKE_LINK_DEPENDS_NO_SHARED ${ARGUMENT_LINK_DEPENDS_NO_SHARED})
+    endif()
+
     add_executable(${TARGET_NAME} ${ALL_SOURCES})
 
     if (NOT ${ARGUMENT_NO_INSTALL})

--- a/doc/page-cmakefunctions.h
+++ b/doc/page-cmakefunctions.h
@@ -50,6 +50,7 @@ facelift_add_qml_plugin(<TargetName>
                         [HEADERS_GLOB_NO_INSTALL [Globbing expressions]...]
                         [HEADERS_GLOB_RECURSE_NO_INSTALL [Globbing expressions]...]
                         [LINK_LIBRARIES lib1 [lib2...]]
+                        [LINK_DEPENDS_NO_SHARED <ON|OFF>]
                         [NO_INSTALL])
 \endcode
 
@@ -72,6 +73,7 @@ facelift_add_library(<TargetName>
                      [LINK_LIBRARIES lib1 [lib2...]]
                      [NO_EXPORT]
                      [NO_INSTALL]
+                     [LINK_DEPENDS_NO_SHARED <ON|OFF>]
                      [MONOLITHIC_SUPPORTED])
 \endcode
 
@@ -85,7 +87,8 @@ facelift_add_executable(<TargetName>
                         [HEADERS_GLOB ghdr1 [Globbing expressions]...]
                         [SOURCES_GLOB_RECURSE [Globbing expressions]...]
                         [HEADERS_GLOB_RECURSE [Globbing expressions]...]
-                        [LINK_LIBRARIES lib1 [lib2...]])
+                        [LINK_LIBRARIES lib1 [lib2...]]
+                        [LINK_DEPENDS_NO_SHARED <ON|OFF>])
 
 \endcode
 
@@ -99,7 +102,8 @@ facelift_add_test(<TargetName>
                   [HEADERS_GLOB [Globbing expressions]...]
                   [SOURCES_GLOB_RECURSE [Globbing expressions]...]
                   [HEADERS_GLOB_RECURSE [Globbing expressions]...]
-                  [LINK_LIBRARIES lib1 [lib2...]])
+                  [LINK_LIBRARIES lib1 [lib2...]]
+                  [LINK_DEPENDS_NO_SHARED <ON|OFF>])
 \endcode
 
 
@@ -124,5 +128,6 @@ This function adds a test with the name \e TargetName.The parameter descriptions
 \param URI The URI of the Target i.e qml plugin
 \param VERSION The target i.e Qml plugin version, if not provided it defaults to 1.0
 \param MONOLITHIC_SUPPORTED Include the library into the monolithic library
+\param LINK_DEPENDS_NO_SHARED Append cmake property LINK_DEPENDS_NO_SHARED to the target
 
 */


### PR DESCRIPTION
The reason behind adding LINK_DEPENDS_NO_SHARED as a parameter:
- LINK_DEPENDS_NO_SHARED can't be a global property. It might be set only for a specific target and since facelift CMake API changes the name of the target the most correct way of adding it is to add it as a parameter.
- The second solution would be to set/unset CMAKE_LINK_DEPENDS_NO_SHARED every time facelift API is called in the client but IMHO it looks more hackish and less straightforward.